### PR TITLE
feat: add service auth to sensor scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,24 @@ Common conventions:
 - Timeouts / TTLs: end with `_MINUTES`, `_DAYS`, or `_SECONDS`
 - Booleans: use `1`/`0` or `true`/`false` strings
 
+Sensor scripts that post readings to the backend should authenticate with a
+service-account JWT when the backend enforces auth:
+
+```env
+SERVICE_ACCOUNT_TOKEN=eyJ...
+```
+
+Create the token by registering or provisioning a user with the
+`service_account` role, then logging in through the orchestrator auth API. During
+the transition from the legacy backend, scripts may also send a long-lived API
+key fallback:
+
+```env
+LEGACY_API_KEY=your-long-lived-key
+```
+
+When both are set, scripts must prefer `SERVICE_ACCOUNT_TOKEN`.
+
 ## Database Access
 
 - **MySQL**: Use `sqlalchemy.ext.asyncio` (AsyncSession) via the shared engine/pool from `orchestrator/core/database.py`.

--- a/medium home/frontend/frontend.py
+++ b/medium home/frontend/frontend.py
@@ -20,6 +20,8 @@ if not HA_TOKEN:
 
 
 BACKEND_URL = "http://127.0.0.1:5000/readings/add"
+SERVICE_ACCOUNT_TOKEN = os.getenv("SERVICE_ACCOUNT_TOKEN")
+LEGACY_API_KEY = os.getenv("LEGACY_API_KEY")
 
 
 # Device IDs (home_id: 3 — Professor's House)
@@ -86,13 +88,25 @@ HA_HEADERS = {
 }
 
 
+BACKEND_HEADERS = {"Content-Type": "application/json"}
+if SERVICE_ACCOUNT_TOKEN:
+    BACKEND_HEADERS["Authorization"] = f"Bearer {SERVICE_ACCOUNT_TOKEN}"
+elif LEGACY_API_KEY:
+    BACKEND_HEADERS["X-API-Key"] = LEGACY_API_KEY
+
+
 last_motion_state = None
 
 
 # ── Helpers ────────────────────────────────────────────────────
 def post_readings(payload):
     try:
-        resp = requests.post(BACKEND_URL, json=payload, timeout=5)
+        resp = requests.post(
+            BACKEND_URL,
+            json=payload,
+            headers=BACKEND_HEADERS,
+            timeout=5,
+        )
         return resp.json()
     except requests.RequestException as e:
         print(f"  [ERROR] Backend unreachable: {e}")

--- a/medium home/sensors/logger.py
+++ b/medium home/sensors/logger.py
@@ -19,6 +19,8 @@ if not HA_TOKEN:
     raise ValueError("HA_TOKEN not found in .env file — please add it")
 
 BACKEND_URL = "http://127.0.0.1:5000/readings/add"
+SERVICE_ACCOUNT_TOKEN = os.getenv("SERVICE_ACCOUNT_TOKEN")
+LEGACY_API_KEY = os.getenv("LEGACY_API_KEY")
 
 # Sutton's Home
 HOME_ID = 1
@@ -63,10 +65,22 @@ HA_HEADERS = {
 }
 
 
+BACKEND_HEADERS = {"Content-Type": "application/json"}
+if SERVICE_ACCOUNT_TOKEN:
+    BACKEND_HEADERS["Authorization"] = f"Bearer {SERVICE_ACCOUNT_TOKEN}"
+elif LEGACY_API_KEY:
+    BACKEND_HEADERS["X-API-Key"] = LEGACY_API_KEY
+
+
 # ── Helpers ────────────────────────────────────────────────────
 def post_readings(payload):
     try:
-        resp = requests.post(BACKEND_URL, json=payload, timeout=5)
+        resp = requests.post(
+            BACKEND_URL,
+            json=payload,
+            headers=BACKEND_HEADERS,
+            timeout=5,
+        )
         print(f"[POST] status={resp.status_code}")
 
         # Try to print backend response for debugging

--- a/medium home/sensors/sound_logger.py
+++ b/medium home/sensors/sound_logger.py
@@ -2,10 +2,16 @@ import sounddevice as sd
 import numpy as np
 import requests
 import time
+import os
 from collections import deque
+from dotenv import load_dotenv
+
+load_dotenv()
 
 API_URL = "http://127.0.0.1:5000/readings/add"
 DEVICE_ID = 6
+SERVICE_ACCOUNT_TOKEN = os.getenv("SERVICE_ACCOUNT_TOKEN")
+LEGACY_API_KEY = os.getenv("LEGACY_API_KEY")
 
 SAMPLE_RATE = 44100
 DURATION = 0.5
@@ -17,6 +23,12 @@ SPIKE_MARGIN_DB = 10.0    # how much louder than baseline counts as a spike
 MIN_SPIKE_LEVEL = -30.0   # optional floor so tiny changes in silence don't trigger
 
 recent_levels = deque(maxlen=BASELINE_WINDOW)
+
+API_HEADERS = {"Content-Type": "application/json"}
+if SERVICE_ACCOUNT_TOKEN:
+    API_HEADERS["Authorization"] = f"Bearer {SERVICE_ACCOUNT_TOKEN}"
+elif LEGACY_API_KEY:
+    API_HEADERS["X-API-Key"] = LEGACY_API_KEY
 
 
 def get_sound_level():
@@ -61,7 +73,7 @@ while True:
             }
         }
 
-        r = requests.post(API_URL, json=payload, timeout=5)
+        r = requests.post(API_URL, json=payload, headers=API_HEADERS, timeout=5)
         print(
             f"sound={sound_level} dB | baseline={baseline:.2f} dB | "
             f"spike={spike} | status={r.status_code}"


### PR DESCRIPTION
## Summary
- Added service-account JWT authentication headers to sensor scripts that post readings to the backend.
- Added `SERVICE_ACCOUNT_TOKEN` support using `Authorization: Bearer <token>`.
- Added `LEGACY_API_KEY` fallback support using `X-API-Key` during the transition period.
- Updated `frontend.py`, `logger.py`, and `sound_logger.py` to include auth headers on backend reading submissions.
- Documented service-account token setup and legacy API key fallback in `AGENTS.md`.
