### PR TITLE
feat: add orchestrator end-to-end integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/orchestrator/api/ontology.py
+++ b/orchestrator/api/ontology.py
@@ -1,6 +1,8 @@
 """Ontology API routes."""
 
 from typing import Annotated
+import tempfile
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
 
@@ -118,7 +120,9 @@ async def upload_ontology(
             detail="Only .ttl files are accepted",
         )
     content = await file.read()
-    temp_path = "/tmp/uploaded_ontology.ttl"
+    temp_dir = tempfile.gettempdir()
+    temp_path = os.path.join(temp_dir, "uploaded_ontology.ttl")
+    # temp_path = "/tmp/uploaded_ontology.ttl"
     with open(temp_path, "wb") as f:
         f.write(content)
     result = await load_ontology(temp_path)

--- a/orchestrator/tests/test_e2e_workflow.py
+++ b/orchestrator/tests/test_e2e_workflow.py
@@ -1,0 +1,160 @@
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest, os
+
+
+@pytest.mark.anyio
+async def test_full_device_monitoring_flow(
+    client,
+    override_mysql_session,
+    override_current_user,
+):
+    """
+    End-to-end workflow test:
+
+    register -> device control -> agent task
+    """
+
+    # ==========================================
+    # MOCK DATABASE RESPONSES
+    # ==========================================
+
+    mock_session = override_mysql_session
+
+    mock_result = MagicMock()
+
+    mock_result.mappings.return_value.all.return_value = [
+    {
+        "id": 1,
+        "name": "Living Room Lamp",
+        "device_type": "SmartBulb",
+        "room_id": 1,
+        "is_active": True,
+    }
+    ]
+
+    mock_session.execute = AsyncMock(return_value=mock_result)    
+    # ==========================================
+    # STEP 1 — LIST DEVICES
+    # ==========================================
+
+    resp = client.get("/devices")
+
+    assert resp.status_code == 200
+
+    # ==========================================
+    # STEP 2 — TURN DEVICE ON
+    # ==========================================
+
+    resp = client.post("/devices/1/on")
+
+    assert resp.status_code == 200
+
+    data = resp.json()
+
+    assert data["state"] == "on"
+
+    # ==========================================
+    # STEP 3 — MOCK AGENT ORCHESTRATOR
+    # ==========================================
+
+    with patch(
+        "orchestrator.api.mcp._orchestrator.submit",
+        new=AsyncMock(return_value="task-123"),
+    ):
+
+        task_payload = {
+            "intent": "monitor_energy",
+            "payload": {
+                "device_id": 1,
+                "power": 1200,
+            },
+        }
+
+        resp = client.post(
+            "/mcp/task",
+            json=task_payload,
+        )
+
+        assert resp.status_code == 202
+
+        body = resp.json()
+
+        assert body["task_id"] == "task-123"
+
+        assert body["status"] == "submitted"
+
+
+from orchestrator.mcp.tools.ha_tools import (
+    HAGetStateInput,
+    ha_get_state_handler,
+)
+
+
+@pytest.mark.anyio
+async def test_mocked_homeassistant_state():
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "entity_id": "light.living_room",
+        "state": "on",
+        "attributes": {
+            "brightness": 255
+        },
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+
+    with (
+        patch.dict(os.environ, {"HA_TOKEN": "fake-token"}),
+        patch("httpx.AsyncClient") as mock_async_client,
+    ):
+
+        mock_async_client.return_value.__aenter__.return_value = (
+            mock_client
+        )
+
+        result = await ha_get_state_handler(
+            HAGetStateInput(
+                entity_id="light.living_room"
+            )
+        )
+
+        assert result["state"] == "on"
+
+        assert result["attributes"]["brightness"] == 255
+
+
+from orchestrator.llm.client import LLMClient
+
+
+@pytest.mark.anyio
+async def test_mocked_ollama_response():
+
+    mock_response = MagicMock()
+
+    mock_response.json.return_value = {
+        "response": (
+            "High energy usage detected. "
+            "Recommend turning off idle devices."
+        )
+    }
+
+    mock_response.raise_for_status.return_value = None
+
+    mock_post = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "httpx.AsyncClient.post",
+        new=mock_post,
+    ):
+
+        client = LLMClient()
+
+        result = await client.generate(
+            prompt="Analyze energy spike",
+        )
+
+        assert "High energy usage" in result


### PR DESCRIPTION
Implemented the requirements from Issue #44 by adding:

- end-to-end workflow integration tests for device orchestration and MCP task execution
- mocked Home Assistant API testing
- deterministic mocked Ollama response testing
- cross-platform fix for ontology temporary file handling (Windows/Linux/macOS compatibility)
- 
Validation
- full pytest suite passing (50 passed)