### PR TITLE
Issue 7 user schema

### DIFF
--- a/database_schema.txt
+++ b/database_schema.txt
@@ -65,3 +65,43 @@ CREATE TABLE device_profiles (
     motion_timeout_minutes INT,
     FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
 );
+
+CREATE TABLE households (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    address VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL,
+    hashed_password VARCHAR(255) NOT NULL,
+    role ENUM(
+        'superadmin',
+        'homeowner',
+        'family_member',
+        'guest',
+        'service_account'
+    ) NOT NULL DEFAULT 'guest',
+    household_id INT,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_email (email),
+    INDEX idx_users_household_id (household_id),
+    INDEX idx_users_role (role),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE SET NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE user_sessions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    refresh_token VARCHAR(512) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_refresh_token (refresh_token),
+    INDEX idx_user_sessions_user_id (user_id),
+    INDEX idx_user_sessions_expires_at (expires_at),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;

--- a/database_schema.txt
+++ b/database_schema.txt
@@ -1,20 +1,54 @@
+CREATE TABLE households (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    address VARCHAR(255),
+    home_assistant_url VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
 CREATE TABLE rooms (
     id INT AUTO_INCREMENT PRIMARY KEY,
+    household_id INT,
     name VARCHAR(100) NOT NULL COLLATE utf8mb4_general_ci,
     description VARCHAR(255),
-    UNIQUE KEY unique_room_name (name)
-);
+    ha_area_id VARCHAR(100),
+    UNIQUE KEY unique_household_room_name (household_id, name),
+    UNIQUE KEY unique_household_ha_area (household_id, ha_area_id),
+    INDEX idx_rooms_household_id (household_id),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
 
 CREATE TABLE devices (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL COLLATE utf8mb4_general_ci,
     ip_address VARCHAR(50),
-    device_type ENUM('smart_plug', 'motion_sensor', 'sound_sensor', 'other') NOT NULL,
+    device_type ENUM(
+        'smart_plug',
+        'motion_sensor',
+        'sound_sensor',
+        'light',
+        'switch',
+        'cover',
+        'climate',
+        'valve',
+        'fan',
+        'media_player',
+        'sensor',
+        'other'
+    ) NOT NULL,
     room_id INT,
+    ha_device_id VARCHAR(64),
+    ha_entity_id VARCHAR(255),
+    ha_platform VARCHAR(100),
+    manufacturer VARCHAR(100),
+    model VARCHAR(100),
     is_active BOOLEAN DEFAULT TRUE,
     UNIQUE KEY unique_device_name (name),
+    UNIQUE KEY unique_ha_entity_id (ha_entity_id),
+    INDEX idx_devices_room_id (room_id),
+    INDEX idx_devices_ha_device_id (ha_device_id),
     FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE SET NULL
-);
+) ENGINE=InnoDB;
 
 CREATE TABLE sensor_readings (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -66,23 +100,16 @@ CREATE TABLE device_profiles (
     FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
 );
 
-CREATE TABLE households (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(100) NOT NULL,
-    address VARCHAR(255),
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB;
-
 CREATE TABLE users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     email VARCHAR(255) NOT NULL,
     hashed_password VARCHAR(255) NOT NULL,
     role ENUM(
-        'superadmin',
-        'homeowner',
-        'family_member',
         'guest',
-        'service_account'
+        'family_member',
+        'homeowner',
+        'service_account',
+        'superadmin'
     ) NOT NULL DEFAULT 'guest',
     household_id INT,
     is_active BOOLEAN DEFAULT TRUE,
@@ -104,4 +131,52 @@ CREATE TABLE user_sessions (
     INDEX idx_user_sessions_user_id (user_id),
     INDEX idx_user_sessions_expires_at (expires_at),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE user_room_access (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    room_id INT NOT NULL,
+    permission VARCHAR(50) NOT NULL DEFAULT 'room:read',
+    allowed_start_hour TINYINT,
+    allowed_end_hour TINYINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_room_permission (user_id, room_id, permission),
+    INDEX idx_user_room_access_room_id (room_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE user_device_access (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    device_id INT NOT NULL,
+    permission VARCHAR(50) NOT NULL DEFAULT 'device:read',
+    allowed_start_hour TINYINT,
+    allowed_end_hour TINYINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_device_permission (user_id, device_id, permission),
+    INDEX idx_user_device_access_device_id (device_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE home_assistant_entities (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    household_id INT NOT NULL,
+    ha_entity_id VARCHAR(255) NOT NULL,
+    ha_device_id VARCHAR(64),
+    ha_area_id VARCHAR(100),
+    domain VARCHAR(50) NOT NULL,
+    platform VARCHAR(100),
+    friendly_name VARCHAR(255),
+    original_name VARCHAR(255),
+    entity_category VARCHAR(100),
+    disabled_by VARCHAR(100),
+    metadata JSON,
+    synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_household_ha_entity (household_id, ha_entity_id),
+    INDEX idx_ha_entities_device_id (ha_device_id),
+    INDEX idx_ha_entities_area_id (ha_area_id),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;

--- a/scripts/migrate_add_users.sql
+++ b/scripts/migrate_add_users.sql
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS users (
     is_active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_users_household_id (household_id),
+    INDEX idx_users_role (role),
     FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE SET NULL
 ) ENGINE=InnoDB;
 
@@ -26,5 +28,8 @@ CREATE TABLE IF NOT EXISTS user_sessions (
     refresh_token VARCHAR(512) NOT NULL,
     expires_at TIMESTAMP NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_refresh_token (refresh_token),
+    INDEX idx_user_sessions_user_id (user_id),
+    INDEX idx_user_sessions_expires_at (expires_at),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;

--- a/scripts/migrate_add_users.sql
+++ b/scripts/migrate_add_users.sql
@@ -1,10 +1,11 @@
--- Migration: add users, households, and user_sessions tables
+-- Migration: add auth, access-control, and Home Assistant inventory tables
 -- Issue #7
 
 CREATE TABLE IF NOT EXISTS households (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     address VARCHAR(255),
+    home_assistant_url VARCHAR(255),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
@@ -12,7 +13,7 @@ CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     email VARCHAR(255) NOT NULL UNIQUE,
     hashed_password VARCHAR(255) NOT NULL,
-    role ENUM('superadmin', 'homeowner', 'family_member', 'guest', 'service_account') NOT NULL DEFAULT 'guest',
+    role ENUM('guest', 'family_member', 'homeowner', 'service_account', 'superadmin') NOT NULL DEFAULT 'guest',
     household_id INT,
     is_active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -32,4 +33,52 @@ CREATE TABLE IF NOT EXISTS user_sessions (
     INDEX idx_user_sessions_user_id (user_id),
     INDEX idx_user_sessions_expires_at (expires_at),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS user_room_access (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    room_id INT NOT NULL,
+    permission VARCHAR(50) NOT NULL DEFAULT 'room:read',
+    allowed_start_hour TINYINT,
+    allowed_end_hour TINYINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_room_permission (user_id, room_id, permission),
+    INDEX idx_user_room_access_room_id (room_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS user_device_access (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    device_id INT NOT NULL,
+    permission VARCHAR(50) NOT NULL DEFAULT 'device:read',
+    allowed_start_hour TINYINT,
+    allowed_end_hour TINYINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_device_permission (user_id, device_id, permission),
+    INDEX idx_user_device_access_device_id (device_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS home_assistant_entities (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    household_id INT NOT NULL,
+    ha_entity_id VARCHAR(255) NOT NULL,
+    ha_device_id VARCHAR(64),
+    ha_area_id VARCHAR(100),
+    domain VARCHAR(50) NOT NULL,
+    platform VARCHAR(100),
+    friendly_name VARCHAR(255),
+    original_name VARCHAR(255),
+    entity_category VARCHAR(100),
+    disabled_by VARCHAR(100),
+    metadata JSON,
+    synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_household_ha_entity (household_id, ha_entity_id),
+    INDEX idx_ha_entities_device_id (ha_device_id),
+    INDEX idx_ha_entities_area_id (ha_area_id),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;


### PR DESCRIPTION
- Expanded the database schema beyond placeholder user tables.
- Added `households` support with optional Home Assistant URL tracking.
- Updated `rooms` to support household ownership and Home Assistant area IDs.
- Updated `devices` to store Home Assistant metadata such as entity ID, device ID, platform, manufacturer, and model.
- Added `home_assistant_entities` to preserve Home Assistant entity registry data without forcing every HA entity to become a primary EcoNest device.
- Added `user_room_access` and `user_device_access` tables for future room/device-scoped permissions.
- Restored the role model used by issue 9: `guest`, `family_member`, `homeowner`, `service_account`, and `superadmin`.
- Updated the migration script to create the same auth, access-control, and Home Assistant inventory tables.