### PR TITLE
Issue 8 security utils

### DIFF
--- a/database_schema.txt
+++ b/database_schema.txt
@@ -65,3 +65,43 @@ CREATE TABLE device_profiles (
     motion_timeout_minutes INT,
     FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
 );
+
+CREATE TABLE households (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    address VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL,
+    hashed_password VARCHAR(255) NOT NULL,
+    role ENUM(
+        'superadmin',
+        'homeowner',
+        'family_member',
+        'guest',
+        'service_account'
+    ) NOT NULL DEFAULT 'guest',
+    household_id INT,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_email (email),
+    INDEX idx_users_household_id (household_id),
+    INDEX idx_users_role (role),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE SET NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE user_sessions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    refresh_token VARCHAR(512) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_refresh_token (refresh_token),
+    INDEX idx_user_sessions_user_id (user_id),
+    INDEX idx_user_sessions_expires_at (expires_at),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;

--- a/database_schema.txt
+++ b/database_schema.txt
@@ -1,20 +1,54 @@
+CREATE TABLE households (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    address VARCHAR(255),
+    home_assistant_url VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
 CREATE TABLE rooms (
     id INT AUTO_INCREMENT PRIMARY KEY,
+    household_id INT,
     name VARCHAR(100) NOT NULL COLLATE utf8mb4_general_ci,
     description VARCHAR(255),
-    UNIQUE KEY unique_room_name (name)
-);
+    ha_area_id VARCHAR(100),
+    UNIQUE KEY unique_household_room_name (household_id, name),
+    UNIQUE KEY unique_household_ha_area (household_id, ha_area_id),
+    INDEX idx_rooms_household_id (household_id),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
 
 CREATE TABLE devices (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL COLLATE utf8mb4_general_ci,
     ip_address VARCHAR(50),
-    device_type ENUM('smart_plug', 'motion_sensor', 'sound_sensor', 'other') NOT NULL,
+    device_type ENUM(
+        'smart_plug',
+        'motion_sensor',
+        'sound_sensor',
+        'light',
+        'switch',
+        'cover',
+        'climate',
+        'valve',
+        'fan',
+        'media_player',
+        'sensor',
+        'other'
+    ) NOT NULL,
     room_id INT,
+    ha_device_id VARCHAR(64),
+    ha_entity_id VARCHAR(255),
+    ha_platform VARCHAR(100),
+    manufacturer VARCHAR(100),
+    model VARCHAR(100),
     is_active BOOLEAN DEFAULT TRUE,
     UNIQUE KEY unique_device_name (name),
+    UNIQUE KEY unique_ha_entity_id (ha_entity_id),
+    INDEX idx_devices_room_id (room_id),
+    INDEX idx_devices_ha_device_id (ha_device_id),
     FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE SET NULL
-);
+) ENGINE=InnoDB;
 
 CREATE TABLE sensor_readings (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -66,23 +100,16 @@ CREATE TABLE device_profiles (
     FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
 );
 
-CREATE TABLE households (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(100) NOT NULL,
-    address VARCHAR(255),
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB;
-
 CREATE TABLE users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     email VARCHAR(255) NOT NULL,
     hashed_password VARCHAR(255) NOT NULL,
     role ENUM(
-        'superadmin',
-        'homeowner',
-        'family_member',
         'guest',
-        'service_account'
+        'family_member',
+        'homeowner',
+        'service_account',
+        'superadmin'
     ) NOT NULL DEFAULT 'guest',
     household_id INT,
     is_active BOOLEAN DEFAULT TRUE,
@@ -104,4 +131,52 @@ CREATE TABLE user_sessions (
     INDEX idx_user_sessions_user_id (user_id),
     INDEX idx_user_sessions_expires_at (expires_at),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE user_room_access (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    room_id INT NOT NULL,
+    permission VARCHAR(50) NOT NULL DEFAULT 'room:read',
+    allowed_start_hour TINYINT,
+    allowed_end_hour TINYINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_room_permission (user_id, room_id, permission),
+    INDEX idx_user_room_access_room_id (room_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE user_device_access (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    device_id INT NOT NULL,
+    permission VARCHAR(50) NOT NULL DEFAULT 'device:read',
+    allowed_start_hour TINYINT,
+    allowed_end_hour TINYINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_device_permission (user_id, device_id, permission),
+    INDEX idx_user_device_access_device_id (device_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE home_assistant_entities (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    household_id INT NOT NULL,
+    ha_entity_id VARCHAR(255) NOT NULL,
+    ha_device_id VARCHAR(64),
+    ha_area_id VARCHAR(100),
+    domain VARCHAR(50) NOT NULL,
+    platform VARCHAR(100),
+    friendly_name VARCHAR(255),
+    original_name VARCHAR(255),
+    entity_category VARCHAR(100),
+    disabled_by VARCHAR(100),
+    metadata JSON,
+    synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_household_ha_entity (household_id, ha_entity_id),
+    INDEX idx_ha_entities_device_id (ha_device_id),
+    INDEX idx_ha_entities_area_id (ha_area_id),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;

--- a/orchestrator/core/security.py
+++ b/orchestrator/core/security.py
@@ -1,7 +1,10 @@
 """Password hashing and JWT token utilities."""
 
+import hashlib
+import hmac
+import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Optional
 
 import bcrypt
 from jose import JWTError, jwt
@@ -18,35 +21,69 @@ def hash_password(plain: str) -> str:
 
 def verify_password(plain: str, hashed: str) -> bool:
     """Verify a plain-text password against a bcrypt hash."""
-    return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
+    try:
+        return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
+    except (TypeError, ValueError):
+        return False
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     """Create a JWT access token."""
-    to_encode = data.copy()
-    expire = datetime.now(timezone.utc) + (
-        expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return _create_token(
+        data=data,
+        token_type="access",
+        expires_delta=expires_delta
+        or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
     )
-    to_encode.update({"exp": expire, "type": "access"})
-    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
 
 def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     """Create a JWT refresh token."""
-    to_encode = data.copy()
-    expire = datetime.now(timezone.utc) + (
-        expires_delta or timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    return _create_token(
+        data=data,
+        token_type="refresh",
+        expires_delta=expires_delta
+        or timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
     )
-    to_encode.update({"exp": expire, "type": "refresh"})
-    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
 
-def decode_token(token: str) -> Optional[dict]:
+def decode_token(token: str, expected_type: Optional[str] = None) -> Optional[dict[str, Any]]:
     """Decode and validate a JWT token. Returns None if invalid."""
     try:
         payload = jwt.decode(
-            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
         )
-        return payload
     except JWTError:
         return None
+
+    if expected_type is not None and payload.get("type") != expected_type:
+        return None
+    return payload
+
+
+def hash_refresh_token(token: str) -> str:
+    """Hash a refresh token for storage."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def verify_refresh_token(token: str, token_hash: str) -> bool:
+    """Verify a refresh token against a stored SHA-256 hash."""
+    return hmac.compare_digest(hash_refresh_token(token), token_hash)
+
+
+def _create_token(data: dict, token_type: str, expires_delta: timedelta) -> str:
+    """Create a JWT with standard EcoNest claims."""
+    now = datetime.now(timezone.utc)
+    expire = now + expires_delta
+    to_encode = data.copy()
+    to_encode.update(
+        {
+            "exp": expire,
+            "iat": now,
+            "jti": str(uuid.uuid4()),
+            "type": token_type,
+        }
+    )
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)

--- a/orchestrator/tests/test_security.py
+++ b/orchestrator/tests/test_security.py
@@ -1,0 +1,61 @@
+"""Tests for security utilities."""
+
+from datetime import timedelta
+
+from orchestrator.core.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    hash_password,
+    hash_refresh_token,
+    verify_password,
+    verify_refresh_token,
+)
+
+
+def test_password_hash_and_verify() -> None:
+    hashed = hash_password("secret")
+
+    assert hashed != "secret"
+    assert verify_password("secret", hashed)
+    assert not verify_password("wrong", hashed)
+
+
+def test_verify_password_handles_invalid_hash() -> None:
+    assert not verify_password("secret", "not-a-bcrypt-hash")
+
+
+def test_access_token_contains_standard_claims() -> None:
+    token = create_access_token({"sub": "1", "role": "homeowner"})
+
+    payload = decode_token(token, expected_type="access")
+
+    assert payload is not None
+    assert payload["sub"] == "1"
+    assert payload["role"] == "homeowner"
+    assert payload["type"] == "access"
+    assert "iat" in payload
+    assert "jti" in payload
+    assert "exp" in payload
+
+
+def test_decode_token_rejects_wrong_type() -> None:
+    token = create_refresh_token({"sub": "1"})
+
+    assert decode_token(token, expected_type="access") is None
+    assert decode_token(token, expected_type="refresh") is not None
+
+
+def test_decode_token_rejects_expired_token() -> None:
+    token = create_access_token({"sub": "1"}, expires_delta=timedelta(seconds=-1))
+
+    assert decode_token(token) is None
+
+
+def test_refresh_token_hashing() -> None:
+    token = create_refresh_token({"sub": "1"})
+    token_hash = hash_refresh_token(token)
+
+    assert token_hash != token
+    assert verify_refresh_token(token, token_hash)
+    assert not verify_refresh_token("different-token", token_hash)

--- a/scripts/migrate_add_users.sql
+++ b/scripts/migrate_add_users.sql
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS users (
     is_active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_users_household_id (household_id),
+    INDEX idx_users_role (role),
     FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE SET NULL
 ) ENGINE=InnoDB;
 
@@ -26,5 +28,8 @@ CREATE TABLE IF NOT EXISTS user_sessions (
     refresh_token VARCHAR(512) NOT NULL,
     expires_at TIMESTAMP NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_refresh_token (refresh_token),
+    INDEX idx_user_sessions_user_id (user_id),
+    INDEX idx_user_sessions_expires_at (expires_at),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;

--- a/scripts/migrate_add_users.sql
+++ b/scripts/migrate_add_users.sql
@@ -1,10 +1,11 @@
--- Migration: add users, households, and user_sessions tables
+-- Migration: add auth, access-control, and Home Assistant inventory tables
 -- Issue #7
 
 CREATE TABLE IF NOT EXISTS households (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     address VARCHAR(255),
+    home_assistant_url VARCHAR(255),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
@@ -12,7 +13,7 @@ CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     email VARCHAR(255) NOT NULL UNIQUE,
     hashed_password VARCHAR(255) NOT NULL,
-    role ENUM('superadmin', 'homeowner', 'family_member', 'guest', 'service_account') NOT NULL DEFAULT 'guest',
+    role ENUM('guest', 'family_member', 'homeowner', 'service_account', 'superadmin') NOT NULL DEFAULT 'guest',
     household_id INT,
     is_active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -32,4 +33,52 @@ CREATE TABLE IF NOT EXISTS user_sessions (
     INDEX idx_user_sessions_user_id (user_id),
     INDEX idx_user_sessions_expires_at (expires_at),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS user_room_access (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    room_id INT NOT NULL,
+    permission VARCHAR(50) NOT NULL DEFAULT 'room:read',
+    allowed_start_hour TINYINT,
+    allowed_end_hour TINYINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_room_permission (user_id, room_id, permission),
+    INDEX idx_user_room_access_room_id (room_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS user_device_access (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    device_id INT NOT NULL,
+    permission VARCHAR(50) NOT NULL DEFAULT 'device:read',
+    allowed_start_hour TINYINT,
+    allowed_end_hour TINYINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_device_permission (user_id, device_id, permission),
+    INDEX idx_user_device_access_device_id (device_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS home_assistant_entities (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    household_id INT NOT NULL,
+    ha_entity_id VARCHAR(255) NOT NULL,
+    ha_device_id VARCHAR(64),
+    ha_area_id VARCHAR(100),
+    domain VARCHAR(50) NOT NULL,
+    platform VARCHAR(100),
+    friendly_name VARCHAR(255),
+    original_name VARCHAR(255),
+    entity_category VARCHAR(100),
+    disabled_by VARCHAR(100),
+    metadata JSON,
+    synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_household_ha_entity (household_id, ha_entity_id),
+    INDEX idx_ha_entities_device_id (ha_device_id),
+    INDEX idx_ha_entities_area_id (ha_area_id),
+    FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;


### PR DESCRIPTION
- Hardened password verification so invalid bcrypt hashes fail safely instead of raising errors.
- Added standard JWT claims to generated access and refresh tokens, including `iat`, `jti`, `exp`, and token `type`.
- Added token type validation so callers can explicitly require either an access token or refresh token.
- Added refresh token hashing helpers so refresh tokens can be stored as hashes instead of plaintext.
- Updated refresh token verification to use constant-time hash comparison.
- Added security utility tests for password hashing, token claims, token type checks, expired tokens, and refresh token hashing.
- Kept token role coverage aligned with the issue 9 role model.