### PR TITLE
Secure auth token flow

### DIFF
--- a/orchestrator/api/auth.py
+++ b/orchestrator/api/auth.py
@@ -16,6 +16,7 @@ from orchestrator.core.security import (
     create_access_token,
     create_refresh_token,
     decode_token,
+    hash_refresh_token,
     hash_password,
     verify_password,
 )
@@ -30,6 +31,11 @@ class RegisterRequest(BaseModel):
     email: EmailStr
     password: str
     role: Role = Role.HOMEOWNER
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
 
 
 class TokenResponse(BaseModel):
@@ -65,8 +71,8 @@ async def get_current_user(
             detail="Not authenticated",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    payload = decode_token(token)
-    if payload is None or payload.get("type") != "access":
+    payload = decode_token(token, expected_type="access")
+    if payload is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
@@ -141,7 +147,7 @@ async def register(
 
 @router.post("/login", response_model=TokenResponse)
 async def login(
-    req: RegisterRequest,
+    req: LoginRequest,
     session: AsyncSession = Depends(get_mysql_session),
 ):
     """OAuth2 password flow — returns access + refresh tokens."""
@@ -167,6 +173,7 @@ async def login(
     user_id = str(row["id"])
     access_token = create_access_token({"sub": user_id, "role": row["role"]})
     refresh_token = create_refresh_token({"sub": user_id})
+    refresh_token_hash = hash_refresh_token(refresh_token)
 
     expires_at = datetime.now(timezone.utc) + timedelta(
         days=settings.REFRESH_TOKEN_EXPIRE_DAYS
@@ -178,7 +185,7 @@ async def login(
         ),
         {
             "user_id": row["id"],
-            "refresh_token": refresh_token,
+            "refresh_token": refresh_token_hash,
             "expires_at": expires_at,
         },
     )
@@ -193,8 +200,8 @@ async def refresh(
     session: AsyncSession = Depends(get_mysql_session),
 ):
     """Refresh access token using a valid refresh token."""
-    payload = decode_token(req.refresh_token)
-    if payload is None or payload.get("type") != "refresh":
+    payload = decode_token(req.refresh_token, expected_type="refresh")
+    if payload is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token",
@@ -213,7 +220,10 @@ async def refresh(
             "WHERE user_id = :user_id AND refresh_token = :refresh_token "
             "AND expires_at > NOW()"
         ),
-        {"user_id": int(user_id), "refresh_token": req.refresh_token},
+        {
+            "user_id": int(user_id),
+            "refresh_token": hash_refresh_token(req.refresh_token),
+        },
     )
     if result.scalar() is None:
         raise HTTPException(
@@ -245,7 +255,7 @@ async def logout(
     if req.refresh_token:
         await session.execute(
             text("DELETE FROM user_sessions WHERE refresh_token = :token"),
-            {"token": req.refresh_token},
+            {"token": hash_refresh_token(req.refresh_token)},
         )
         await session.commit()
     return None

--- a/orchestrator/tests/test_auth.py
+++ b/orchestrator/tests/test_auth.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from orchestrator.core.security import (
     create_access_token,
     create_refresh_token,
+    hash_refresh_token,
     hash_password,
 )
 from orchestrator.main import app
@@ -109,6 +110,9 @@ async def test_login_success(client, mock_session):
     data = resp.json()
     assert "access_token" in data
     assert "refresh_token" in data
+    stored_session = mock_session.execute.await_args_list[1].args[1]
+    assert stored_session["refresh_token"] == hash_refresh_token(data["refresh_token"])
+    assert stored_session["refresh_token"] != data["refresh_token"]
 
 
 @pytest.mark.anyio
@@ -136,11 +140,21 @@ async def test_refresh_success(client, mock_session):
     assert resp.status_code == 200
     data = resp.json()
     assert "access_token" in data
+    session_lookup = mock_session.execute.await_args_list[0].args[1]
+    assert session_lookup["refresh_token"] == hash_refresh_token(refresh)
+    assert session_lookup["refresh_token"] != refresh
 
 
 @pytest.mark.anyio
 async def test_refresh_invalid_token(client, mock_session):
     resp = client.post("/auth/refresh", json={"refresh_token": "invalid.token.here"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_refresh_rejects_access_token(client, mock_session):
+    access = create_access_token({"sub": "1", "role": "homeowner"})
+    resp = client.post("/auth/refresh", json={"refresh_token": access})
     assert resp.status_code == 401
 
 
@@ -151,8 +165,12 @@ async def test_refresh_invalid_token(client, mock_session):
 
 @pytest.mark.anyio
 async def test_logout_success(client, mock_session):
-    resp = client.post("/auth/logout", json={"refresh_token": "some_token"})
+    refresh = create_refresh_token({"sub": "1"})
+    resp = client.post("/auth/logout", json={"refresh_token": refresh})
     assert resp.status_code == 204
+    delete_params = mock_session.execute.await_args.args[1]
+    assert delete_params["token"] == hash_refresh_token(refresh)
+    assert delete_params["token"] != refresh
 
 
 # ------------------------------------------------------------------
@@ -179,6 +197,13 @@ async def test_me_success(client, mock_session):
 
 
 @pytest.mark.anyio
+async def test_me_rejects_refresh_token(client, mock_session):
+    token = create_refresh_token({"sub": "1"})
+    resp = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
 async def test_me_no_token(client):
     resp = client.get("/auth/me")
     assert resp.status_code == 401
@@ -191,7 +216,6 @@ async def test_me_no_token(client):
 
 @pytest.mark.anyio
 async def test_list_users_admin_only(client, mock_session):
-    # Guest token
     token = create_access_token({"sub": "2", "role": "guest"})
     mock_session.execute.return_value = _mock_result(
         {


### PR DESCRIPTION
Issue10:
- Split login into a dedicated request model so login no longer accepts registration-only role fields.
- Validated access and refresh tokens by expected token type at each auth endpoint.
- Stored refresh tokens as SHA-256 hashes in user_sessions instead of storing raw refresh tokens.
- Looked up and revoked refresh sessions using hashed refresh-token values.
- Added auth tests for hashed refresh-token storage, refresh lookup, logout revocation, and rejecting wrong token types.