### PR TITLE
Complete user management API

### DIFF
--- a/orchestrator/api/users.py
+++ b/orchestrator/api/users.py
@@ -9,12 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from orchestrator.api.auth import UserProfile, get_current_user
 from orchestrator.core.database import get_mysql_session
-from orchestrator.core.permissions import (
-    USER_ADMIN,
-    USER_WRITE,
-    has_permission,
-    normalize_role,
-)
+from orchestrator.core.permissions import USER_ADMIN, has_permission, normalize_role
 from orchestrator.graph.builder import grant_access_to_graph
 
 router = APIRouter(prefix="/users", tags=["users"])
@@ -92,17 +87,21 @@ async def update_user(
     session: AsyncSession = Depends(get_mysql_session),
 ):
     """Update user (self or admin)."""
-    if current_user.id != user_id and not has_permission(current_user.role, USER_WRITE):
+    is_admin = has_permission(current_user.role, USER_ADMIN)
+    if current_user.id != user_id and not is_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot update other users",
         )
-
-    # Non-admins cannot change role
-    if req.role is not None and not has_permission(current_user.role, USER_ADMIN):
+    if req.role is not None and not is_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only admins can change roles",
+        )
+    if req.is_active is not None and not is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admins can change active status",
         )
 
     fields = []
@@ -162,6 +161,17 @@ async def deactivate_user(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot deactivate yourself",
         )
+
+    existing = await session.execute(
+        text("SELECT id FROM users WHERE id = :id"),
+        {"id": user_id},
+    )
+    if existing.scalar() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
     await session.execute(
         text("UPDATE users SET is_active = FALSE WHERE id = :id"),
         {"id": user_id},
@@ -185,8 +195,27 @@ async def grant_access(
             detail="room_id or device_id required",
         )
 
+    target_user = await session.execute(
+        text("SELECT id FROM users WHERE id = :id"),
+        {"id": user_id},
+    )
+    if target_user.scalar() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
     permission = req.permission
     if req.room_id is not None:
+        room = await session.execute(
+            text("SELECT id FROM rooms WHERE id = :id"),
+            {"id": req.room_id},
+        )
+        if room.scalar() is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Room not found",
+            )
         await session.execute(
             text(
                 "INSERT INTO user_room_access "
@@ -206,6 +235,15 @@ async def grant_access(
             },
         )
     if req.device_id is not None:
+        device = await session.execute(
+            text("SELECT id FROM devices WHERE id = :id"),
+            {"id": req.device_id},
+        )
+        if device.scalar() is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Device not found",
+            )
         await session.execute(
             text(
                 "INSERT INTO user_device_access "

--- a/orchestrator/tests/test_auth.py
+++ b/orchestrator/tests/test_auth.py
@@ -295,3 +295,84 @@ async def test_grant_room_access_writes_access_table(client, mock_session):
         allowed_start_hour=None,
         allowed_end_hour=None,
     )
+
+
+# ------------------------------------------------------------------
+# Service account authentication
+# ------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_service_account_login_success(client, mock_session):
+    hashed = hash_password("service-secret")
+    mock_session.execute.return_value = _mock_result(
+        {
+            "id": 10,
+            "email": "service@example.com",
+            "hashed_password": hashed,
+            "role": "service_account",
+            "is_active": True,
+        }
+    )
+
+    resp = client.post(
+        "/auth/login",
+        json={"email": "service@example.com", "password": "service-secret"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+    stored_session = mock_session.execute.await_args_list[1].args[1]
+    assert stored_session["refresh_token"] == hash_refresh_token(data["refresh_token"])
+
+
+@pytest.mark.anyio
+async def test_service_account_can_submit_mcp_task(client, mock_session):
+    token = create_access_token({"sub": "10", "role": "service_account"})
+    mock_session.execute.return_value = _mock_result(
+        {
+            "id": 10,
+            "email": "service@example.com",
+            "role": "service_account",
+            "household_id": None,
+            "is_active": True,
+        }
+    )
+
+    with patch("orchestrator.api.mcp._orchestrator.submit", new=AsyncMock(return_value="task-1")):
+        resp = client.post(
+            "/mcp/task",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"intent": "sensor_health", "payload": {}},
+        )
+
+    assert resp.status_code == 202
+    assert resp.json() == {"task_id": "task-1", "status": "submitted"}
+
+
+@pytest.mark.anyio
+async def test_service_account_cannot_write_devices(client, mock_session):
+    token = create_access_token({"sub": "10", "role": "service_account"})
+    mock_session.execute.return_value = _mock_result(
+        {
+            "id": 10,
+            "email": "service@example.com",
+            "role": "service_account",
+            "household_id": None,
+            "is_active": True,
+        }
+    )
+
+    resp = client.post("/devices/1/on", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 403
+    assert mock_session.commit.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_protected_endpoint_requires_token(client):
+    resp = client.post("/mcp/task", json={"intent": "sensor_health", "payload": {}})
+
+    assert resp.status_code == 401

--- a/orchestrator/tests/test_auth.py
+++ b/orchestrator/tests/test_auth.py
@@ -266,6 +266,8 @@ async def test_grant_room_access_writes_access_table(client, mock_session):
                 "is_active": True,
             }
         ),
+        _mock_result({"id": 7}),
+        _mock_result({"id": 10}),
         _mock_result(None),
     ]
 
@@ -280,9 +282,9 @@ async def test_grant_room_access_writes_access_table(client, mock_session):
         )
 
     assert resp.status_code == 204
-    assert mock_session.execute.await_count == 2
+    assert mock_session.execute.await_count == 4
     assert mock_session.commit.await_count == 1
-    access_query = str(mock_session.execute.await_args_list[1].args[0])
+    access_query = str(mock_session.execute.await_args_list[3].args[0])
     assert "permission = VALUES(permission)" in access_query
     graph_grant.assert_awaited_once_with(
         mysql_session=mock_session,

--- a/orchestrator/tests/test_users.py
+++ b/orchestrator/tests/test_users.py
@@ -1,0 +1,265 @@
+"""Tests for user management API routes."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from orchestrator.core.security import create_access_token
+from orchestrator.main import app
+
+
+@pytest.fixture
+def client():
+    """Return a TestClient for the FastAPI app."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_session():
+    """Return a mocked async SQLAlchemy session."""
+    return AsyncMock(spec=AsyncSession)
+
+
+@pytest.fixture(autouse=True)
+def override_get_mysql_session(mock_session):
+    """Override the get_mysql_session dependency with a mock."""
+    from orchestrator.core.database import get_mysql_session
+
+    async def _override():
+        return mock_session
+
+    app.dependency_overrides[get_mysql_session] = _override
+    yield
+    app.dependency_overrides.clear()
+
+
+def _mock_result(row: dict | None = None, rows: list[dict] | None = None):
+    """Build a mocked SQLAlchemy result."""
+    result = MagicMock()
+    result.mappings.return_value.first.return_value = row
+    result.mappings.return_value.all.return_value = rows or ([] if row is None else [row])
+    result.scalar.return_value = row.get("id") if row else None
+    return result
+
+
+def _token(user_id: int, role: str) -> str:
+    return create_access_token({"sub": str(user_id), "role": role})
+
+
+@pytest.mark.anyio
+async def test_list_users_admin_only_success(client, mock_session):
+    mock_session.execute.side_effect = [
+        _mock_result(
+            {
+                "id": 1,
+                "email": "admin@example.com",
+                "role": "superadmin",
+                "household_id": None,
+                "is_active": True,
+            }
+        ),
+        _mock_result(
+            rows=[
+                {
+                    "id": 1,
+                    "email": "admin@example.com",
+                    "role": "superadmin",
+                    "household_id": None,
+                    "is_active": True,
+                },
+                {
+                    "id": 2,
+                    "email": "user@example.com",
+                    "role": "homeowner",
+                    "household_id": 1,
+                    "is_active": True,
+                },
+            ]
+        ),
+    ]
+
+    resp = client.get("/users", headers={"Authorization": f"Bearer {_token(1, 'superadmin')}"})
+
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+@pytest.mark.anyio
+async def test_get_user_self_success(client, mock_session):
+    user = {
+        "id": 2,
+        "email": "user@example.com",
+        "role": "homeowner",
+        "household_id": 1,
+        "is_active": True,
+    }
+    mock_session.execute.side_effect = [_mock_result(user), _mock_result(user)]
+
+    resp = client.get("/users/2", headers={"Authorization": f"Bearer {_token(2, 'homeowner')}"})
+
+    assert resp.status_code == 200
+    assert resp.json()["email"] == "user@example.com"
+
+
+@pytest.mark.anyio
+async def test_get_user_other_requires_admin(client, mock_session):
+    mock_session.execute.return_value = _mock_result(
+        {
+            "id": 2,
+            "email": "user@example.com",
+            "role": "homeowner",
+            "household_id": 1,
+            "is_active": True,
+        }
+    )
+
+    resp = client.get("/users/3", headers={"Authorization": f"Bearer {_token(2, 'homeowner')}"})
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_update_self_email_success(client, mock_session):
+    before = {
+        "id": 2,
+        "email": "old@example.com",
+        "role": "homeowner",
+        "household_id": 1,
+        "is_active": True,
+    }
+    after = {**before, "email": "new@example.com"}
+    mock_session.execute.side_effect = [_mock_result(before), _mock_result(None), _mock_result(after)]
+
+    resp = client.put(
+        "/users/2",
+        headers={"Authorization": f"Bearer {_token(2, 'homeowner')}"},
+        json={"email": "new@example.com"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["email"] == "new@example.com"
+    assert mock_session.commit.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_update_other_user_requires_admin(client, mock_session):
+    mock_session.execute.return_value = _mock_result(
+        {
+            "id": 2,
+            "email": "user@example.com",
+            "role": "homeowner",
+            "household_id": 1,
+            "is_active": True,
+        }
+    )
+
+    resp = client.put(
+        "/users/3",
+        headers={"Authorization": f"Bearer {_token(2, 'homeowner')}"},
+        json={"email": "other@example.com"},
+    )
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_non_admin_cannot_change_active_status(client, mock_session):
+    mock_session.execute.return_value = _mock_result(
+        {
+            "id": 2,
+            "email": "user@example.com",
+            "role": "homeowner",
+            "household_id": 1,
+            "is_active": True,
+        }
+    )
+
+    resp = client.put(
+        "/users/2",
+        headers={"Authorization": f"Bearer {_token(2, 'homeowner')}"},
+        json={"is_active": False},
+    )
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_deactivate_user_success(client, mock_session):
+    mock_session.execute.side_effect = [
+        _mock_result(
+            {
+                "id": 1,
+                "email": "admin@example.com",
+                "role": "superadmin",
+                "household_id": None,
+                "is_active": True,
+            }
+        ),
+        _mock_result({"id": 2}),
+        _mock_result(None),
+    ]
+
+    resp = client.delete("/users/2", headers={"Authorization": f"Bearer {_token(1, 'superadmin')}"})
+
+    assert resp.status_code == 204
+    assert mock_session.commit.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_grant_device_access_success(client, mock_session):
+    mock_session.execute.side_effect = [
+        _mock_result(
+            {
+                "id": 1,
+                "email": "admin@example.com",
+                "role": "superadmin",
+                "household_id": None,
+                "is_active": True,
+            }
+        ),
+        _mock_result({"id": 2}),
+        _mock_result({"id": 99}),
+        _mock_result(None),
+    ]
+
+    with patch("orchestrator.api.users.grant_access_to_graph", new=AsyncMock()) as grant:
+        resp = client.post(
+            "/users/2/grant-access",
+            headers={"Authorization": f"Bearer {_token(1, 'superadmin')}"},
+            json={"device_id": 99, "permission": "device:read"},
+        )
+
+    assert resp.status_code == 204
+    assert mock_session.commit.await_count == 1
+    grant.assert_awaited_once_with(
+        mysql_session=mock_session,
+        user_id=2,
+        room_id=None,
+        device_id=99,
+        permission="device:read",
+        allowed_start_hour=None,
+        allowed_end_hour=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_grant_access_requires_room_or_device(client, mock_session):
+    mock_session.execute.return_value = _mock_result(
+        {
+            "id": 1,
+            "email": "admin@example.com",
+            "role": "superadmin",
+            "household_id": None,
+            "is_active": True,
+        }
+    )
+
+    resp = client.post(
+        "/users/2/grant-access",
+        headers={"Authorization": f"Bearer {_token(1, 'superadmin')}"},
+        json={},
+    )
+
+    assert resp.status_code == 400


### PR DESCRIPTION
Issue 11:
- Completed user management API behavior for listing, reading, updating, deactivating, and granting access to users.
- Tightened update authorization so users can update themselves, while other-user updates require admin access.
- Restricted role and active-status changes to admins.
- Added 404 handling when deactivating a missing user.
- Validated target users, rooms, and devices before writing room/device access grants.
- Kept access grants writing to SQL ACL tables and syncing graph access relationships.
- Added dedicated tests for list/get/update/delete/grant-access user API behavior.