### PR TITLE
Feat issue #17: implement graph API

### DIFF
--- a/orchestrator/api/graph.py
+++ b/orchestrator/api/graph.py
@@ -1,13 +1,20 @@
 """Graph API routes for ArcadeDB operations."""
 
-from typing import Annotated, List
+import re
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from orchestrator.api.auth import UserProfile, get_current_user
-from orchestrator.core.database import arcadedb_query, healthcheck_arcadedb
+from orchestrator.core.database import (
+    arcadedb_query,
+    get_mysql_session,
+    healthcheck_arcadedb,
+)
 from orchestrator.core.permissions import USER_ADMIN, has_permission
+from orchestrator.graph.builder import ConflictPolicy, incremental_sync
 from orchestrator.graph.queries import (
     get_devices_in_room,
 )
@@ -16,79 +23,176 @@ router = APIRouter(prefix="/graph", tags=["graph"])
 
 
 class RoomSummary(BaseModel):
+    id: str | None = None
     name: str
     device_count: int
 
 
+class DevicesResponse(BaseModel):
+    room_id: str
+    devices: list[dict[str, Any]]
+
+
+class NeighborsResponse(BaseModel):
+    device_id: str
+    neighbors: list[dict[str, Any]]
+
+
 class GremlinQuery(BaseModel):
-    query: str
+    query: str = Field(min_length=1, max_length=5000)
+
+
+class RawQueryResponse(BaseModel):
+    result: list[Any]
+
+
+class GraphSyncRequest(BaseModel):
+    last_sync: str = Field(default="1970-01-01 00:00:00")
+    conflict_policy: ConflictPolicy = "update"
+
+
+class GraphSyncResponse(BaseModel):
+    changed_rooms: int
+    changed_devices: int
+    changed_sensor_readings: int
+    last_sync: str
+    conflict_policy: ConflictPolicy
 
 
 @router.get("/health")
-async def graph_health():
+async def graph_health() -> dict[str, str]:
     """ArcadeDB connectivity check."""
     ok = await healthcheck_arcadedb()
     return {"status": "ok" if ok else "unhealthy", "service": "arcadedb"}
 
 
-@router.get("/rooms", response_model=List[RoomSummary])
+@router.get("/rooms", response_model=list[RoomSummary])
 async def list_rooms(
     current_user: Annotated[UserProfile, Depends(get_current_user)],
-):
+) -> list[RoomSummary]:
     """List rooms with device counts."""
     result = await arcadedb_query(
         "gremlin",
-        "g.V().hasLabel('Room').as('room').in('LOCATED_IN').count().as('count').select('room','count')",
+        (
+            "g.V().hasLabel('Room')"
+            ".project('room','count')"
+            ".by(valueMap(true))"
+            ".by(__.in('LOCATED_IN').hasLabel('Device').count())"
+        ),
     )
-    rooms = []
+    rooms: list[RoomSummary] = []
     for item in result.get("result", []):
+        if not isinstance(item, dict):
+            continue
         room_data = item.get("room", {})
-        count = item.get("count", 0)
-        rooms.append(RoomSummary(name=room_data.get("name", ""), device_count=count))
+        if not isinstance(room_data, dict):
+            continue
+        rooms.append(
+            RoomSummary(
+                id=_first_string(room_data.get("@rid") or room_data.get("id")),
+                name=_first_string(room_data.get("name")) or "",
+                device_count=int(item.get("count") or 0),
+            )
+        )
     return rooms
 
 
-@router.get("/rooms/{room_id}/devices")
+@router.get("/rooms/{room_id}/devices", response_model=DevicesResponse)
 async def room_devices(
     room_id: str,
     current_user: Annotated[UserProfile, Depends(get_current_user)],
-):
+) -> DevicesResponse:
     """Devices in a room."""
     devices = await get_devices_in_room(room_id)
-    return {"room_id": room_id, "devices": devices}
+    return DevicesResponse(room_id=room_id, devices=devices)
 
 
-@router.get("/devices/{device_id}/neighbors")
+@router.get("/devices/{device_id}/neighbors", response_model=NeighborsResponse)
 async def device_neighbors(
     device_id: str,
     current_user: Annotated[UserProfile, Depends(get_current_user)],
-):
+) -> NeighborsResponse:
     """Related devices, circuits, and rooms."""
     result = await arcadedb_query(
         "gremlin",
-        f"g.V('{device_id}').bothE().otherV().valueMap()",
+        f"g.V('{_escape_gremlin_string(device_id)}').bothE().otherV().valueMap(true)",
     )
-    return {"device_id": device_id, "neighbors": result.get("result", [])}
+    return NeighborsResponse(
+        device_id=device_id,
+        neighbors=[row for row in result.get("result", []) if isinstance(row, dict)],
+    )
 
 
-@router.post("/query")
+@router.post("/query", response_model=RawQueryResponse)
 async def raw_query(
     req: GremlinQuery,
     current_user: Annotated[UserProfile, Depends(get_current_user)],
-):
+) -> RawQueryResponse:
     """Raw Gremlin query (admin only, with validation)."""
     if not has_permission(current_user.role, USER_ADMIN):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
         )
-    # Basic validation: reject destructive commands
-    forbidden = {"drop", "delete", "remove", "truncate"}
-    lower_q = req.query.lower()
-    if any(word in lower_q for word in forbidden):
+    _validate_readonly_gremlin(req.query)
+    result = await arcadedb_query("gremlin", req.query)
+    return RawQueryResponse(result=result.get("result", []))
+
+
+@router.post("/sync", response_model=GraphSyncResponse)
+async def sync_graph(
+    req: GraphSyncRequest,
+    current_user: Annotated[UserProfile, Depends(get_current_user)],
+    mysql_session: Annotated[AsyncSession, Depends(get_mysql_session)],
+) -> GraphSyncResponse:
+    """Trigger MySQL to ArcadeDB graph sync."""
+    if not has_permission(current_user.role, USER_ADMIN):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    result = await incremental_sync(
+        mysql_session=mysql_session,
+        last_sync=req.last_sync,
+        conflict_policy=req.conflict_policy,
+    )
+    return GraphSyncResponse(**result)
+
+
+def _validate_readonly_gremlin(query: str) -> None:
+    normalized = query.strip()
+    if not normalized.startswith("g."):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Destructive queries are not allowed",
+            detail="Only Gremlin traversals starting with g. are allowed",
         )
-    result = await arcadedb_query("gremlin", req.query)
-    return {"result": result.get("result", [])}
+
+    forbidden_patterns = (
+        r"\bdrop\s*\(",
+        r"\bdelete\b",
+        r"\bremove\s*\(",
+        r"\btruncate\b",
+        r"\baddv\s*\(",
+        r"\badde\s*\(",
+        r"\bproperty\s*\(",
+        r"\bsideeffect\s*\(",
+    )
+    lower_query = normalized.lower()
+    if any(re.search(pattern, lower_query) for pattern in forbidden_patterns):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Destructive or mutating Gremlin queries are not allowed",
+        )
+
+
+def _first_string(value: Any) -> str | None:
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if value is None:
+        return None
+    return str(value)
+
+
+def _escape_gremlin_string(value: str) -> str:
+    """Escape a string for single-quoted Gremlin literals."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")

--- a/orchestrator/tests/test_graph.py
+++ b/orchestrator/tests/test_graph.py
@@ -93,6 +93,14 @@ def _mock_queries_arcadedb(result_data: dict):
     )
 
 
+def _mock_builder_sync(result_data: dict):
+    """Helper to patch incremental graph sync in api.graph module."""
+    return patch(
+        "orchestrator.api.graph.incremental_sync",
+        new=AsyncMock(return_value=result_data),
+    )
+
+
 def _mock_mysql_row(row: dict | None):
     result = MagicMock()
     result.mappings.return_value.first.return_value = row
@@ -288,17 +296,21 @@ async def test_list_rooms(client):
     with _mock_arcadedb_result(
         {
             "result": [
-                {"room": {"name": "Kitchen"}, "count": 3},
-                {"room": {"name": "Garage"}, "count": 1},
+                {"room": {"@rid": "#1:0", "name": ["Kitchen"]}, "count": 3},
+                {"room": {"@rid": "#1:1", "name": ["Garage"]}, "count": 1},
             ]
         }
-    ):
+    ) as query:
         resp = client.get("/graph/rooms")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 2
+    assert data[0]["id"] == "#1:0"
     assert data[0]["name"] == "Kitchen"
     assert data[0]["device_count"] == 3
+    command = query.await_args.args[1]
+    assert ".project('room','count')" in command
+    assert ".by(__.in('LOCATED_IN').hasLabel('Device').count())" in command
 
 
 # ------------------------------------------------------------------
@@ -383,10 +395,22 @@ async def test_get_sensor_coverage_uses_monitors_edge():
 
 @pytest.mark.anyio
 async def test_device_neighbors(client):
-    with _mock_arcadedb_result({"result": [{"name": ["Kitchen"]}]}):
+    with _mock_arcadedb_result({"result": [{"name": ["Kitchen"]}]}) as query:
         resp = client.get("/graph/devices/%232:0/neighbors")
     assert resp.status_code == 200
     assert len(resp.json()["neighbors"]) == 1
+    command = query.await_args.args[1]
+    assert ".bothE().otherV().valueMap(true)" in command
+
+
+@pytest.mark.anyio
+async def test_device_neighbors_escapes_rid_literals(client):
+    with _mock_arcadedb_result({"result": []}) as query:
+        resp = client.get("/graph/devices/%232:%27bad/neighbors")
+
+    assert resp.status_code == 200
+    command = query.await_args.args[1]
+    assert "#2:\\'bad" in command
 
 
 # ------------------------------------------------------------------
@@ -411,7 +435,17 @@ async def test_raw_query_forbidden_words(client):
         json={"query": "g.V().drop()"},
     )
     assert resp.status_code == 400
-    assert "Destructive" in resp.json()["detail"]
+    assert "mutating" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_raw_query_requires_gremlin_traversal(client):
+    resp = client.post(
+        "/graph/query",
+        json={"query": "SELECT FROM Room"},
+    )
+    assert resp.status_code == 400
+    assert "g." in resp.json()["detail"]
 
 
 @pytest.mark.anyio
@@ -422,6 +456,48 @@ async def test_raw_query_non_admin(client, guest_user):
         json={"query": "g.V().valueMap()"},
     )
     assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_graph_sync_admin(client):
+    session = AsyncMock()
+    app.dependency_overrides[get_mysql_session] = lambda: session
+    sync_result = {
+        "changed_rooms": 1,
+        "changed_devices": 2,
+        "changed_sensor_readings": 3,
+        "last_sync": "2026-05-24 15:00:00",
+        "conflict_policy": "skip",
+    }
+
+    with _mock_builder_sync(sync_result) as sync:
+        resp = client.post(
+            "/graph/sync",
+            json={
+                "last_sync": "2026-05-24 15:00:00",
+                "conflict_policy": "skip",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == sync_result
+    sync.assert_awaited_once_with(
+        mysql_session=session,
+        last_sync="2026-05-24 15:00:00",
+        conflict_policy="skip",
+    )
+
+
+@pytest.mark.anyio
+async def test_graph_sync_non_admin_forbidden(client, guest_user):
+    app.dependency_overrides[get_current_user] = lambda: guest_user
+    app.dependency_overrides[get_mysql_session] = lambda: AsyncMock()
+
+    with _mock_builder_sync({}) as sync:
+        resp = client.post("/graph/sync", json={})
+
+    assert resp.status_code == 403
+    sync.assert_not_awaited()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
- Add typed graph API request and response models.
- Improve room listing with ArcadeDB device counts using LOCATED_IN relationships.
- Harden graph device neighbor and raw Gremlin query routes with escaped IDs and read-only validation.
- Add POST /graph/sync to trigger MySQL to ArcadeDB incremental sync.
- Add route tests for graph rooms, devices, raw queries, sync behavior, and permission boundaries.