### PR TITLE
Feat issue #21: implement ontology reasoner

### DIFF
--- a/orchestrator/ontology/reasoner.py
+++ b/orchestrator/ontology/reasoner.py
@@ -1,88 +1,333 @@
-"""Forward chaining reasoner using Gremlin traversals."""
+"""Forward-chaining ontology reasoner for the EcoNest ArcadeDB graph."""
 
+import json
+from enum import Enum
+from pathlib import Path
 from typing import Any
 
+from pydantic import BaseModel, Field
+
 from orchestrator.core.database import arcadedb_query
+from orchestrator.graph.models import ActionName, CapabilityName, DeviceType, RoomType
+
+DEFAULT_RULES_PATH = Path(__file__).parent / "rules.json"
 
 
-async def run_reasoner() -> dict[str, Any]:
-    """Run forward chaining rules and return inferred triples summary.
+class CapabilityRule(BaseModel):
+    """Infer capabilities for devices with a specific graph device_type."""
 
-    Rules:
-    1. If device type is SmartBulb, infer hasCapability Dimmable.
-    2. If device type is MotionSensor and locatedIn Room, infer monitors Room.
-    3. If user role is family_member and room_type is Bedroom, infer CAN_PERFORM TurnOn.
-    """
+    device_type: DeviceType
+    capabilities: list[CapabilityName] = Field(min_length=1)
+
+
+class MonitorRule(BaseModel):
+    """Infer Sensor nodes and MONITORS edges for sensor-like devices."""
+
+    device_type: DeviceType
+    sensor_type: str = Field(min_length=1)
+    confidence_score: float = Field(default=0.9, ge=0, le=1)
+
+
+class AccessRule(BaseModel):
+    """Infer user action permissions from room access and room type."""
+
+    role: str = Field(min_length=1)
+    room_type: RoomType
+    action: ActionName
+    capability: CapabilityName | None = None
+
+
+class ReasoningRules(BaseModel):
+    """Configurable rule set for ontology reasoning."""
+
+    capability_rules: list[CapabilityRule] = Field(default_factory=list)
+    monitor_rules: list[MonitorRule] = Field(default_factory=list)
+    access_rules: list[AccessRule] = Field(default_factory=list)
+
+
+async def run_reasoner(rules_path: str | None = None) -> dict[str, Any]:
+    """Run configured forward-chaining rules and return an inference summary."""
+    rules = load_rules(rules_path)
     inferred: list[dict[str, Any]] = []
 
-    # Rule 1: SmartBulb -> hasCapability Dimmable
+    for capability_rule in rules.capability_rules:
+        inferred.extend(await _infer_capabilities(capability_rule))
+
+    for monitor_rule in rules.monitor_rules:
+        inferred.extend(await _infer_monitors(monitor_rule))
+
+    for access_rule in rules.access_rules:
+        inferred.extend(await _infer_can_perform(access_rule))
+
+    return {
+        "inferred": inferred,
+        "total": len(inferred),
+        "rules": {
+            "capability_rules": len(rules.capability_rules),
+            "monitor_rules": len(rules.monitor_rules),
+            "access_rules": len(rules.access_rules),
+        },
+    }
+
+
+def load_rules(rules_path: str | None = None) -> ReasoningRules:
+    """Load a JSON reasoning rule set."""
+    path = Path(rules_path) if rules_path else DEFAULT_RULES_PATH
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return ReasoningRules.model_validate(data)
+
+
+async def _infer_capabilities(rule: CapabilityRule) -> list[dict[str, Any]]:
+    inferred: list[dict[str, Any]] = []
+    for capability in rule.capabilities:
+        await _ensure_capability(capability)
+        result = await arcadedb_query(
+            "gremlin",
+            (
+                "g.V().hasLabel('Device')"
+                f".has('device_type', '{_escape_gremlin(rule.device_type.value)}')"
+                ".as('device')"
+                ".not(outE('HAS_CAPABILITY').inV()"
+                f".has('name', '{_escape_gremlin(capability.value)}'))"
+                ".select('device')"
+                ".values('@rid')"
+            ),
+        )
+        for device_rid in _result_values(result):
+            if not isinstance(device_rid, str):
+                continue
+            await arcadedb_query(
+                "sql",
+                (
+                    "CREATE EDGE HAS_CAPABILITY "
+                    f"FROM {device_rid} "
+                    f"TO (SELECT FROM Capability WHERE name = {_sql_value(capability)})"
+                ),
+                readonly=False,
+            )
+            inferred.append(
+                {
+                    "rule": "device_capability",
+                    "device_type": rule.device_type.value,
+                    "device": device_rid,
+                    "capability": capability.value,
+                }
+            )
+    return inferred
+
+
+async def _infer_monitors(rule: MonitorRule) -> list[dict[str, Any]]:
     result = await arcadedb_query(
         "gremlin",
         (
-            "g.V().hasLabel('Device').has('device_type', 'SmartBulb').as('device')"
-            ".not(outE('HAS_CAPABILITY').inV().has('name', 'Dimmable'))"
-            ".select('device').values('@rid')"
+            "g.V().hasLabel('Device')"
+            f".has('device_type', '{_escape_gremlin(rule.device_type.value)}')"
+            ".as('device')"
+            ".out('LOCATED_IN')"
+            ".hasLabel('Room')"
+            ".as('room')"
+            ".select('device', 'room')"
+            ".by(valueMap(true))"
         ),
     )
-    for rid in _result_values(result):
+
+    inferred: list[dict[str, Any]] = []
+    for pair in _result_dicts(result):
+        device = _nested_dict(pair.get("device"))
+        room = _nested_dict(pair.get("room"))
+        device_name = _first_string(device.get("name"))
+        room_rid = _rid(room)
+        if not device_name or not room_rid:
+            continue
+
         await arcadedb_query(
             "sql",
             (
-                f"CREATE EDGE HAS_CAPABILITY FROM {rid} TO "
-                f"(SELECT FROM Capability WHERE name = 'Dimmable')"
+                "UPDATE Sensor SET "
+                f"name = {_sql_value(device_name)}, "
+                f"sensor_type = {_sql_value(rule.sensor_type)}, "
+                f"ha_entity_id = {_sql_value(_first_string(device.get('ha_entity_id')))}, "
+                "created_at = datetime() "
+                f"UPSERT WHERE name = {_sql_value(device_name)}"
             ),
             readonly=False,
         )
-        inferred.append({"rule": 1, "device": rid, "capability": "Dimmable"})
+        sensor_selector = f"(SELECT FROM Sensor WHERE name = {_sql_value(device_name)})"
+        await arcadedb_query(
+            "sql",
+            f"DELETE EDGE MONITORS FROM {sensor_selector} TO {room_rid}",
+            readonly=False,
+        )
+        await arcadedb_query(
+            "sql",
+            (
+                f"CREATE EDGE MONITORS FROM {sensor_selector} TO {room_rid} "
+                f"SET confidence_score = {rule.confidence_score}"
+            ),
+            readonly=False,
+        )
+        inferred.append(
+            {
+                "rule": "sensor_monitors_room",
+                "device_type": rule.device_type.value,
+                "sensor": device_name,
+                "room": room_rid,
+                "confidence_score": rule.confidence_score,
+            }
+        )
+    return inferred
 
-    # Rule 2: MotionSensor + locatedIn Room -> monitors Room
+
+async def _infer_can_perform(rule: AccessRule) -> list[dict[str, Any]]:
+    await _ensure_action(rule.action)
+    if rule.capability is not None:
+        await _ensure_capability(rule.capability)
+        await arcadedb_query(
+            "sql",
+            (
+                "DELETE EDGE REQUIRES_CAPABILITY "
+                f"FROM (SELECT FROM Action WHERE name = {_sql_value(rule.action)}) "
+                f"TO (SELECT FROM Capability WHERE name = {_sql_value(rule.capability)})"
+            ),
+            readonly=False,
+        )
+        await arcadedb_query(
+            "sql",
+            (
+                "CREATE EDGE REQUIRES_CAPABILITY "
+                f"FROM (SELECT FROM Action WHERE name = {_sql_value(rule.action)}) "
+                f"TO (SELECT FROM Capability WHERE name = {_sql_value(rule.capability)})"
+            ),
+            readonly=False,
+        )
+
     result = await arcadedb_query(
         "gremlin",
         (
-            "g.V().hasLabel('Device').has('device_type', 'MotionSensor')"
-            ".outE('LOCATED_IN').inV().hasLabel('Room').as('room')"
-            ".select('room').path().by(values('@rid'))"
+            "g.V().hasLabel('User')"
+            f".has('role', '{_escape_gremlin(rule.role)}')"
+            ".as('user')"
+            ".out('HAS_ACCESS')"
+            ".hasLabel('Room')"
+            f".has('room_type', '{_escape_gremlin(rule.room_type.value)}')"
+            ".as('room')"
+            ".union(in('LOCATED_IN'), out('CONTAINS').hasLabel('Device'))"
+            ".hasLabel('Device')"
+            ".as('device')"
+            ".select('user', 'device')"
+            ".by(values('@rid'))"
         ),
     )
-    for path in _result_values(result):
-        if isinstance(path, dict) and "objects" in path:
-            objects = path["objects"]
-            if len(objects) >= 2:
-                device_rid = objects[0]
-                room_rid = objects[-1]
-                await arcadedb_query(
-                    "sql",
-                    f"CREATE EDGE MONITORS FROM {device_rid} TO {room_rid}",
-                    readonly=False,
-                )
-                inferred.append({"rule": 2, "device": device_rid, "room": room_rid})
 
-    # Rule 3: family_member + Bedroom -> CAN_PERFORM TurnOn for devices in that room
-    result = await arcadedb_query(
-        "gremlin",
-        (
-            "g.V().hasLabel('User').has('role', 'family_member').as('user')"
-            ".outE('HAS_ACCESS').inV().hasLabel('Room').has('room_type', 'Bedroom')"
-            ".in('LOCATED_IN').hasLabel('Device').as('device')"
-            ".select('user','device').by(values('@rid'))"
-        ),
-    )
-    for pair in _result_values(result):
-        if not isinstance(pair, dict):
-            continue
+    inferred: list[dict[str, Any]] = []
+    seen_users: set[str] = set()
+    for pair in _result_dicts(result):
         user_rid = pair.get("user")
         device_rid = pair.get("device")
-        if user_rid and device_rid:
+        if not isinstance(user_rid, str) or not isinstance(device_rid, str):
+            continue
+        if user_rid not in seen_users:
             await arcadedb_query(
                 "sql",
-                f"CREATE EDGE CAN_PERFORM FROM {user_rid} TO {device_rid}",
+                (
+                    "DELETE EDGE CAN_PERFORM "
+                    f"FROM {user_rid} "
+                    f"TO (SELECT FROM Action WHERE name = {_sql_value(rule.action)})"
+                ),
                 readonly=False,
             )
-            inferred.append({"rule": 3, "user": user_rid, "device": device_rid})
+            await arcadedb_query(
+                "sql",
+                (
+                    "CREATE EDGE CAN_PERFORM "
+                    f"FROM {user_rid} "
+                    f"TO (SELECT FROM Action WHERE name = {_sql_value(rule.action)})"
+                ),
+                readonly=False,
+            )
+            seen_users.add(user_rid)
+        inferred.append(
+            {
+                "rule": "user_can_perform_action",
+                "role": rule.role,
+                "room_type": rule.room_type.value,
+                "user": user_rid,
+                "action": rule.action.value,
+                "device_context": device_rid,
+            }
+        )
+    return inferred
 
-    return {"inferred": inferred, "total": len(inferred)}
+
+async def _ensure_capability(capability: CapabilityName) -> None:
+    await arcadedb_query(
+        "sql",
+        (
+            "UPDATE Capability SET "
+            f"name = {_sql_value(capability)}, "
+            f"description = {_sql_value(f'{capability.value} capability')} "
+            f"UPSERT WHERE name = {_sql_value(capability)}"
+        ),
+        readonly=False,
+    )
+
+
+async def _ensure_action(action: ActionName) -> None:
+    await arcadedb_query(
+        "sql",
+        (
+            "UPDATE Action SET "
+            f"name = {_sql_value(action)}, "
+            "parameters = {}, "
+            "timestamp = datetime() "
+            f"UPSERT WHERE name = {_sql_value(action)}"
+        ),
+        readonly=False,
+    )
 
 
 def _result_values(result: dict[str, Any]) -> list[Any]:
     rows = result.get("result", [])
     return rows if isinstance(rows, list) else [rows]
+
+
+def _result_dicts(result: dict[str, Any]) -> list[dict[str, Any]]:
+    return [row for row in _result_values(result) if isinstance(row, dict)]
+
+
+def _nested_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _rid(row: dict[str, Any]) -> str | None:
+    for key in ("@rid", "id", "rid"):
+        value = row.get(key)
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list) and value and isinstance(value[0], str):
+            return value[0]
+    return None
+
+
+def _first_string(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    if isinstance(value, list) and value and isinstance(value[0], str):
+        return value[0]
+    return None
+
+
+def _sql_value(value: Any) -> str:
+    if isinstance(value, Enum):
+        value = value.value
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return str(value)
+    return "'" + str(value).replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _escape_gremlin(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")

--- a/orchestrator/ontology/rules.json
+++ b/orchestrator/ontology/rules.json
@@ -1,0 +1,68 @@
+{
+  "capability_rules": [
+    {
+      "device_type": "EnergyMonitor",
+      "capabilities": ["PowerMonitoring"]
+    },
+    {
+      "device_type": "SmartPlug",
+      "capabilities": ["OnOff", "PowerMonitoring"]
+    },
+    {
+      "device_type": "SmartBulb",
+      "capabilities": ["OnOff", "Dimmable", "ColorControl"]
+    },
+    {
+      "device_type": "MotionSensor",
+      "capabilities": ["MotionDetection"]
+    },
+    {
+      "device_type": "SoundSensor",
+      "capabilities": ["SoundDetection"]
+    },
+    {
+      "device_type": "Thermostat",
+      "capabilities": ["TemperatureControl"]
+    },
+    {
+      "device_type": "SmartSwitch",
+      "capabilities": ["OnOff"]
+    },
+    {
+      "device_type": "Cover",
+      "capabilities": ["CoverControl"]
+    },
+    {
+      "device_type": "Valve",
+      "capabilities": ["WaterControl"]
+    },
+    {
+      "device_type": "Fan",
+      "capabilities": ["OnOff"]
+    },
+    {
+      "device_type": "MediaPlayer",
+      "capabilities": ["OnOff"]
+    }
+  ],
+  "monitor_rules": [
+    {
+      "device_type": "MotionSensor",
+      "sensor_type": "motion",
+      "confidence_score": 0.9
+    },
+    {
+      "device_type": "SoundSensor",
+      "sensor_type": "sound",
+      "confidence_score": 0.9
+    }
+  ],
+  "access_rules": [
+    {
+      "role": "family_member",
+      "room_type": "Bedroom",
+      "action": "TurnOn",
+      "capability": "OnOff"
+    }
+  ]
+}

--- a/orchestrator/tests/test_ontology.py
+++ b/orchestrator/tests/test_ontology.py
@@ -1,5 +1,6 @@
 """Tests for the ontology layer."""
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -13,6 +14,7 @@ from orchestrator.graph.models import ActionName, CapabilityName, DeviceType, Ro
 from orchestrator.graph.seeds import default_seed_inventory
 from orchestrator.main import app
 from orchestrator.ontology.loader import load_ontology
+from orchestrator.ontology.reasoner import load_rules, run_reasoner
 
 ECONEST = Namespace("http://econest.example.org/ontology#")
 SMART_HOME_TTL = Path(__file__).parents[1] / "ontology" / "smart_home.ttl"
@@ -56,6 +58,12 @@ def ontology_class_name(value: str) -> str:
     if value == DeviceType.PERSON.value:
         return "PersonDevice"
     return value
+
+
+def write_rules(tmp_path: Path, rules: dict) -> str:
+    path = tmp_path / "rules.json"
+    path.write_text(json.dumps(rules), encoding="utf-8")
+    return str(path)
 
 
 # ------------------------------------------------------------------
@@ -383,6 +391,151 @@ async def test_reason(client):
         resp = client.post("/ontology/reason")
     assert resp.status_code == 200
     assert resp.json()["total"] == 0
+
+
+def test_load_reasoner_rules_from_json(tmp_path):
+    rules_path = write_rules(
+        tmp_path,
+        {
+            "capability_rules": [
+                {"device_type": "EnergyMonitor", "capabilities": ["PowerMonitoring"]}
+            ],
+            "monitor_rules": [],
+            "access_rules": [],
+        },
+    )
+
+    rules = load_rules(rules_path)
+
+    assert rules.capability_rules[0].device_type == "EnergyMonitor"
+    assert rules.capability_rules[0].capabilities == ["PowerMonitoring"]
+
+
+@pytest.mark.anyio
+async def test_reasoner_infers_device_capability_edges(tmp_path):
+    rules_path = write_rules(
+        tmp_path,
+        {
+            "capability_rules": [
+                {"device_type": "EnergyMonitor", "capabilities": ["PowerMonitoring"]}
+            ],
+            "monitor_rules": [],
+            "access_rules": [],
+        },
+    )
+
+    async def fake_query(language, command, database=None, readonly=True):
+        if language == "gremlin":
+            return {"result": ["#12:0"]}
+        return {"result": []}
+
+    with patch(
+        "orchestrator.ontology.reasoner.arcadedb_query",
+        new=AsyncMock(side_effect=fake_query),
+    ) as query:
+        result = await run_reasoner(rules_path)
+
+    commands = [call.args[1] for call in query.await_args_list]
+
+    assert result["total"] == 1
+    assert result["inferred"][0]["capability"] == "PowerMonitoring"
+    assert any("UPDATE Capability SET" in command for command in commands)
+    assert any(
+        "CREATE EDGE HAS_CAPABILITY FROM #12:0" in command for command in commands
+    )
+    assert any("WHERE name = 'PowerMonitoring'" in command for command in commands)
+
+
+@pytest.mark.anyio
+async def test_reasoner_infers_sensor_monitor_edges(tmp_path):
+    rules_path = write_rules(
+        tmp_path,
+        {
+            "capability_rules": [],
+            "monitor_rules": [
+                {
+                    "device_type": "MotionSensor",
+                    "sensor_type": "motion",
+                    "confidence_score": 0.9,
+                }
+            ],
+            "access_rules": [],
+        },
+    )
+
+    async def fake_query(language, command, database=None, readonly=True):
+        if language == "gremlin":
+            return {
+                "result": [
+                    {
+                        "device": {
+                            "@rid": "#9:0",
+                            "name": ["Motion Sensor"],
+                            "ha_entity_id": ["binary_sensor.motion_sensor"],
+                        },
+                        "room": {"@rid": "#2:0", "name": ["Front Door"]},
+                    }
+                ]
+            }
+        return {"result": []}
+
+    with patch(
+        "orchestrator.ontology.reasoner.arcadedb_query",
+        new=AsyncMock(side_effect=fake_query),
+    ) as query:
+        result = await run_reasoner(rules_path)
+
+    commands = [call.args[1] for call in query.await_args_list]
+
+    assert result["total"] == 1
+    assert result["inferred"][0]["sensor"] == "Motion Sensor"
+    assert any("UPDATE Sensor SET" in command for command in commands)
+    assert any("DELETE EDGE MONITORS" in command for command in commands)
+    assert any("CREATE EDGE MONITORS" in command for command in commands)
+    assert any("confidence_score = 0.9" in command for command in commands)
+
+
+@pytest.mark.anyio
+async def test_reasoner_infers_user_can_perform_action_edges(tmp_path):
+    rules_path = write_rules(
+        tmp_path,
+        {
+            "capability_rules": [],
+            "monitor_rules": [],
+            "access_rules": [
+                {
+                    "role": "family_member",
+                    "room_type": "Bedroom",
+                    "action": "TurnOn",
+                    "capability": "OnOff",
+                }
+            ],
+        },
+    )
+
+    async def fake_query(language, command, database=None, readonly=True):
+        if language == "gremlin":
+            return {"result": [{"user": "#30:0", "device": "#12:0"}]}
+        return {"result": []}
+
+    with patch(
+        "orchestrator.ontology.reasoner.arcadedb_query",
+        new=AsyncMock(side_effect=fake_query),
+    ) as query:
+        result = await run_reasoner(rules_path)
+
+    commands = [call.args[1] for call in query.await_args_list]
+
+    assert result["total"] == 1
+    assert result["inferred"][0]["action"] == "TurnOn"
+    assert result["inferred"][0]["device_context"] == "#12:0"
+    assert any("UPDATE Action SET" in command for command in commands)
+    assert any("CREATE EDGE REQUIRES_CAPABILITY" in command for command in commands)
+    assert any(
+        "CREATE EDGE CAN_PERFORM FROM #30:0 TO (SELECT FROM Action WHERE name = 'TurnOn')"
+        in command
+        for command in commands
+    )
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
- implement a configurable forward-chaining ontology reasoner using JSON rules
- infer device capabilities using the actual EcoNest graph device types and capability names
- infer Sensor nodes and MONITORS edges for motion and sound devices with confidence scores
- infer user CAN_PERFORM permissions through Action vertices instead of direct User-to-Device edges
- add tests for rule loading, capability inference, monitor inference, and action permission inference