### PR TITLE
feat(issue-25): add structured async llm client

### DIFF
--- a/orchestrator/api/auth.py
+++ b/orchestrator/api/auth.py
@@ -95,13 +95,11 @@ async def get_current_user(
         )
 
     result = await session.execute(
-        text(
-            """
+        text("""
             SELECT id, email, role, household_id, is_active
             FROM users
             WHERE id = :id
-            """
-        ),
+            """),
         {"id": int(user_id)},
     )
 
@@ -148,8 +146,7 @@ async def register(
     hashed = hash_password(req.password)
 
     result = await session.execute(
-        text(
-            """
+        text("""
             INSERT INTO users (
                 email,
                 hashed_password,
@@ -162,8 +159,7 @@ async def register(
                 :role,
                 TRUE
             )
-            """
-        ),
+            """),
         {
             "email": req.email,
             "hashed_password": hashed,
@@ -197,8 +193,7 @@ async def login(
     """OAuth2 password flow."""
 
     result = await session.execute(
-        text(
-            """
+        text("""
             SELECT
                 id,
                 email,
@@ -207,8 +202,7 @@ async def login(
                 is_active
             FROM users
             WHERE email = :email
-            """
-        ),
+            """),
         {"email": form_data.username},
     )
 
@@ -249,8 +243,7 @@ async def login(
     )
 
     await session.execute(
-        text(
-            """
+        text("""
             INSERT INTO user_sessions (
                 user_id,
                 refresh_token,
@@ -261,8 +254,7 @@ async def login(
                 :refresh_token,
                 :expires_at
             )
-            """
-        ),
+            """),
         {
             "user_id": row["id"],
             "refresh_token": hash_refresh_token(refresh_token),
@@ -302,14 +294,12 @@ async def refresh(
         )
 
     result = await session.execute(
-        text(
-            """
+        text("""
             SELECT refresh_token
             FROM user_sessions
             WHERE user_id = :user_id
             AND expires_at > NOW()
-            """
-        ),
+            """),
         {"user_id": int(user_id)},
     )
 
@@ -325,14 +315,12 @@ async def refresh(
         )
 
     user_result = await session.execute(
-        text(
-            """
+        text("""
             SELECT role
             FROM users
             WHERE id = :id
             AND is_active = TRUE
-            """
-        ),
+            """),
         {"id": int(user_id)},
     )
 
@@ -366,12 +354,10 @@ async def logout(
 
     if req.refresh_token:
         await session.execute(
-            text(
-                """
+            text("""
                 DELETE FROM user_sessions
                 WHERE refresh_token = :token
-                """
-            ),
+                """),
             {
                 "token": hash_refresh_token(req.refresh_token),
             },

--- a/orchestrator/llm/client.py
+++ b/orchestrator/llm/client.py
@@ -1,5 +1,6 @@
 """Unified async client for Ollama HTTP API."""
 
+import asyncio
 import json
 from typing import Any, Optional, Type, TypeVar
 
@@ -7,6 +8,7 @@ import httpx
 from pydantic import BaseModel
 
 from orchestrator.config import get_settings
+from orchestrator.llm.models import LLMMessage
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -63,6 +65,7 @@ class LLMClient:
             except Exception:
                 if attempt == max_retries - 1:
                     raise
+                await asyncio.sleep(2**attempt)
         return ""
 
     async def _stream_generate(self, payload: dict[str, Any]) -> str:
@@ -86,21 +89,24 @@ class LLMClient:
 
     async def generate_structured(
         self,
-        prompt: str,
+        messages: list[LLMMessage],
         output_model: Type[T],
         system: Optional[str] = None,
         temperature: float = 0.7,
     ) -> T:
         """Generate structured output validated by a Pydantic model."""
-        structured_prompt = (
-            f"{prompt}\n\n"
-            f"Respond with valid JSON that matches this schema:\n"
+        schema_prompt = (
+            "Respond with valid JSON matching this schema:\n"
             f"{output_model.model_json_schema()}\n"
-            f"Output ONLY the JSON object, no other text."
+            "Output ONLY JSON."
         )
-        raw = await self.generate(
-            structured_prompt,
-            system=system,
+
+        full_messages = [
+            *messages,
+            LLMMessage(role="system", content=schema_prompt),
+        ]
+        raw = await self.chat(
+            full_messages,
             temperature=temperature,
         )
         # Clean up potential markdown fences
@@ -116,14 +122,14 @@ class LLMClient:
 
     async def chat(
         self,
-        messages: list[dict[str, str]],
+        messages: list[LLMMessage],
         temperature: float = 0.7,
         stream: bool = False,
     ) -> str:
         """Chat completion using Ollama's /api/chat endpoint."""
         payload = {
             "model": self.model,
-            "messages": messages,
+            "messages": [m.model_dump() for m in messages],
             "temperature": temperature,
             "stream": stream,
         }
@@ -139,6 +145,14 @@ class LLMClient:
         if not isinstance(message, dict):
             return ""
         return str(message.get("content", ""))
+
+    async def healthcheck(self) -> bool:
+        """Return True if Ollama API is reachable."""
+        try:
+            response = await self.client.get(f"{self.base_url}/api/tags")
+            return response.status_code == 200
+        except Exception:
+            return False
 
     async def close(self) -> None:
         await self.client.aclose()

--- a/orchestrator/llm/models.py
+++ b/orchestrator/llm/models.py
@@ -1,0 +1,14 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class LLMMessage(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+class LLMResponse(BaseModel):
+    content: str
+    model: str
+    raw_response: dict | None = None

--- a/orchestrator/tests/test_llm.py
+++ b/orchestrator/tests/test_llm.py
@@ -1,0 +1,8 @@
+from orchestrator.llm.models import LLMMessage
+
+
+def test_llm_message():
+    msg = LLMMessage(role="user", content="hello")
+
+    assert msg.role == "user"
+    assert msg.content == "hello"


### PR DESCRIPTION
#25
Implemented a structured async LLM client for Ollama with support for retries, streaming, health checks, and Pydantic-based structured outputs. 
 
### Changes

* added typed `LLMMessage` models for message-oriented interactions
* improved async Ollama client abstraction
* added exponential retry backoff
* added Ollama healthcheck support
* added structured JSON generation with Pydantic validation
* refactored chat interactions to use semantic message objects
* added initial LLM tests

This refactor evolves the LLM layer from simple prompt utilities toward reusable cognition infrastructure.
