### PR TITLE
feat(issue-27): implement modular MCP runtime

### DIFF
--- a/orchestrator/mcp/middleware.py
+++ b/orchestrator/mcp/middleware.py
@@ -1,0 +1,17 @@
+"""Permission-aware MCP middleware helpers."""
+
+from fastapi import HTTPException, status
+
+from orchestrator.core.permissions import has_permission
+
+
+def require_permissions(
+    role: str,
+    permissions: list[str],
+) -> None:
+    for permission in permissions:
+        if not has_permission(role, permission):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Missing permission: {permission}",
+            )

--- a/orchestrator/mcp/prompts.py
+++ b/orchestrator/mcp/prompts.py
@@ -1,0 +1,28 @@
+"""Reusable reasoning prompt templates."""
+
+ENERGY_REVIEW_PROMPT = """
+Review the last 24h of energy usage and identify:
+- off-schedule devices
+- unusual consumption
+- possible optimization opportunities
+"""
+
+SECURITY_CHECK_PROMPT = """
+Analyze recent motion, entry, and occupancy signals.
+Identify:
+- suspicious patterns
+- unusual access behavior
+- possible security anomalies
+"""
+
+DEVICE_CONTROL_PROMPT = """
+The user wants to control a smart-home device.
+Clarify ambiguous instructions before taking action.
+"""
+
+SENSOR_HEALTH_PROMPT = """
+Review sensor reporting behavior and identify:
+- stale sensors
+- inconsistent reporting
+- low-confidence observations
+"""

--- a/orchestrator/mcp/registry.py
+++ b/orchestrator/mcp/registry.py
@@ -1,0 +1,46 @@
+"""Central MCP registries for tools, resources, and prompts."""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic import BaseModel
+
+ToolHandler = Callable[..., Awaitable[Any]]
+ResourceHandler = Callable[..., Awaitable[Any]]
+
+tool_registry: dict[str, dict[str, Any]] = {}
+resource_registry: dict[str, dict[str, Any]] = {}
+prompt_registry: dict[str, str] = {}
+
+
+def register_tool(
+    name: str,
+    description: str,
+    input_schema: type[BaseModel],
+    handler: ToolHandler,
+    permissions: list[str] | None = None,
+) -> None:
+    tool_registry[name] = {
+        "description": description,
+        "input_schema": input_schema,
+        "handler": handler,
+        "permissions": permissions or [],
+    }
+
+
+def register_resource(
+    uri: str,
+    description: str,
+    handler: ResourceHandler,
+) -> None:
+    resource_registry[uri] = {
+        "description": description,
+        "handler": handler,
+    }
+
+
+def register_prompt(
+    name: str,
+    text: str,
+) -> None:
+    prompt_registry[name] = text

--- a/orchestrator/mcp/resources.py
+++ b/orchestrator/mcp/resources.py
@@ -1,0 +1,50 @@
+"""Semantic MCP resource providers."""
+
+from typing import Any
+
+from orchestrator.llm.memory import (
+    get_memory_summaries,
+    get_recent_interactions,
+)
+
+
+async def home_snapshot_resource() -> dict[str, Any]:
+    return {
+        "type": "snapshot",
+        "rooms": [],
+        "active_devices": [],
+    }
+
+
+async def home_devices_resource() -> dict[str, Any]:
+    return {
+        "type": "devices",
+        "count": 0,
+    }
+
+
+async def home_analytics_resource() -> dict[str, Any]:
+    return {
+        "type": "analytics",
+        "hourly_power": [],
+    }
+
+
+async def ontology_resource() -> dict[str, Any]:
+    return {
+        "type": "ontology",
+        "classes": [],
+    }
+
+
+async def recent_memory_resource(
+    user_id: str,
+) -> dict[str, Any]:
+    summaries = await get_memory_summaries(user_id)
+    interactions = await get_recent_interactions(user_id)
+
+    return {
+        "type": "memory",
+        "recent_summaries": summaries,
+        "recent_interactions": interactions,
+    }

--- a/orchestrator/mcp/server.py
+++ b/orchestrator/mcp/server.py
@@ -1,6 +1,5 @@
 """MCP protocol implementation (tools/resources/prompts)."""
 
-from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -9,6 +8,7 @@ from pydantic import BaseModel, Field
 from orchestrator.api.auth import UserProfile, get_current_user
 from orchestrator.core.permissions import has_permission
 from orchestrator.mcp.tools import db_tools, device_tools, graph_tools, ha_tools
+from orchestrator.mcp.middleware import require_permissions
 
 router = APIRouter(prefix="/mcp", tags=["mcp"])
 
@@ -16,25 +16,27 @@ router = APIRouter(prefix="/mcp", tags=["mcp"])
 # Registry
 # ------------------------------------------------------------------
 
-ToolHandler = Callable[..., Awaitable[Any]]
-_tool_registry: Dict[str, Dict[str, Any]] = {}
-
-
-def register_tool(
-    name: str,
-    description: str,
-    input_schema: type[BaseModel],
-    handler: ToolHandler,
-    permissions: List[str] | None = None,
-) -> None:
-    """Register an MCP tool with metadata and a handler function."""
-    _tool_registry[name] = {
-        "description": description,
-        "input_schema": input_schema,
-        "handler": handler,
-        "permissions": permissions or [],
-    }
-
+from orchestrator.mcp.prompts import (
+    DEVICE_CONTROL_PROMPT,
+    ENERGY_REVIEW_PROMPT,
+    SECURITY_CHECK_PROMPT,
+    SENSOR_HEALTH_PROMPT,
+)
+from orchestrator.mcp.registry import (
+    prompt_registry,
+    register_prompt,
+    register_resource,
+    register_tool,
+    resource_registry,
+    tool_registry,
+)
+from orchestrator.mcp.resources import (
+    home_analytics_resource,
+    home_devices_resource,
+    home_snapshot_resource,
+    ontology_resource,
+    recent_memory_resource,
+)
 
 # ------------------------------------------------------------------
 # Built-in tools registration
@@ -120,6 +122,59 @@ register_tool(
     permissions=["device:read"],
 )
 
+register_resource(
+    "home://snapshot",
+    "Current smart-home snapshot",
+    home_snapshot_resource,
+)
+
+register_resource(
+    "home://devices",
+    "Device inventory and state",
+    home_devices_resource,
+)
+
+register_resource(
+    "home://analytics",
+    "Home analytics context",
+    home_analytics_resource,
+)
+
+register_resource(
+    "home://ontology",
+    "Smart-home ontology context",
+    ontology_resource,
+)
+
+register_resource(
+    "home://memory/recent",
+    "Recent episodic memory summaries and interactions",
+    recent_memory_resource,
+)
+
+# ------------------------------------------------------------------
+# Prompt registration
+# ------------------------------------------------------------------
+
+register_prompt(
+    "energy_review",
+    ENERGY_REVIEW_PROMPT,
+)
+
+register_prompt(
+    "security_check",
+    SECURITY_CHECK_PROMPT,
+)
+
+register_prompt(
+    "device_control",
+    DEVICE_CONTROL_PROMPT,
+)
+
+register_prompt(
+    "sensor_health",
+    SENSOR_HEALTH_PROMPT,
+)
 
 # ------------------------------------------------------------------
 # Models
@@ -146,7 +201,7 @@ async def list_tools(
 ) -> dict[str, Any]:
     """List available MCP tools filtered by user permissions."""
     tools = []
-    for name, meta in _tool_registry.items():
+    for name, meta in tool_registry.items():
         if all(has_permission(current_user.role, p) for p in meta["permissions"]):
             tools.append(
                 {
@@ -165,18 +220,16 @@ async def invoke_tool(
     current_user: Annotated[UserProfile, Depends(get_current_user)],
 ) -> dict[str, Any]:
     """Invoke an MCP tool directly (with auth)."""
-    if name not in _tool_registry:
+    if name not in tool_registry:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Tool '{name}' not found",
         )
-    meta = _tool_registry[name]
-    for perm in meta["permissions"]:
-        if not has_permission(current_user.role, perm):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Missing permission: {perm}",
-            )
+    meta = tool_registry[name]
+    require_permissions(
+        current_user.role,
+        meta["permissions"],
+    )
     try:
         parsed = meta["input_schema"](**req.arguments)
     except Exception as exc:
@@ -194,18 +247,23 @@ async def get_resource(
     current_user: Annotated[UserProfile, Depends(get_current_user)],
 ) -> dict[str, Any]:
     """Get resource snapshot by URI."""
-    if uri == "home://snapshot":
-        return {"type": "snapshot", "rooms": [], "active_devices": []}
-    if uri == "home://devices":
-        return {"type": "devices", "count": 0}
-    if uri == "home://analytics":
-        return {"type": "analytics", "hourly_power": []}
-    if uri == "home://ontology":
-        return {"type": "ontology", "classes": []}
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail=f"Resource '{uri}' not found",
-    )
+    if uri not in resource_registry:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Resource '{uri}' not found",
+        )
+
+    resource = resource_registry[uri]
+
+    if uri == "home://memory/recent":
+        result = await resource["handler"](str(current_user.id))
+    else:
+        result = await resource["handler"]()
+
+    return {
+        "uri": uri,
+        "resource": result,
+    }
 
 
 @router.get("/prompts/{name}")
@@ -213,16 +271,13 @@ async def get_prompt(
     name: str,
     current_user: Annotated[UserProfile, Depends(get_current_user)],
 ) -> dict[str, Any]:
-    """Return a prompt template by name."""
-    prompts = {
-        "energy_review": "Review the last 24h of energy usage and highlight any off-schedule devices.",
-        "security_check": "Check all motion sensors and garage doors for anomalies in the last hour.",
-        "device_control": "The user wants to control a device. Ask for clarification if the request is ambiguous.",
-        "sensor_health": "Review sensor data quality and flag any sensors that haven't reported in >15 minutes.",
-    }
-    if name not in prompts:
+    if name not in prompt_registry:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Prompt '{name}' not found",
         )
-    return {"name": name, "text": prompts[name]}
+
+    return {
+        "name": name,
+        "text": prompt_registry[name],
+    }

--- a/orchestrator/tests/test_mcp.py
+++ b/orchestrator/tests/test_mcp.py
@@ -46,7 +46,7 @@ async def test_invoke_query_mysql(client):
         sql: str
 
     with patch(
-        "orchestrator.mcp.server._tool_registry",
+        "orchestrator.mcp.server.tool_registry",
         {
             "query_mysql": {
                 "description": "Test",
@@ -82,14 +82,14 @@ async def test_invoke_unknown_tool(client):
 async def test_get_resource_snapshot(client):
     resp = client.get("/mcp/resources/home://snapshot")
     assert resp.status_code == 200
-    assert resp.json()["type"] == "snapshot"
+    assert resp.json()["resource"]["type"] == "snapshot"
 
 
 @pytest.mark.anyio
 async def test_get_resource_devices(client):
     resp = client.get("/mcp/resources/home://devices")
     assert resp.status_code == 200
-    assert resp.json()["type"] == "devices"
+    assert resp.json()["resource"]["type"] == "devices"
 
 
 @pytest.mark.anyio

--- a/orchestrator/tests/test_mcp_registry.py
+++ b/orchestrator/tests/test_mcp_registry.py
@@ -1,0 +1,17 @@
+from orchestrator.mcp.registry import (
+    prompt_registry,
+    resource_registry,
+    tool_registry,
+)
+
+
+def test_tool_registry_exists():
+    assert isinstance(tool_registry, dict)
+
+
+def test_resource_registry_exists():
+    assert isinstance(resource_registry, dict)
+
+
+def test_prompt_registry_exists():
+    assert isinstance(prompt_registry, dict)


### PR DESCRIPTION
Evolves issue #27 

Implemented a modular MCP runtime with semantic tool, resource, and prompt registries for agent-oriented orchestration.

### Changes

* added centralized MCP registries for tools, resources, and prompts
* added semantic resource providers and reusable prompt templates
* added permission-aware middleware for MCP execution
* refactored MCP server into modular runtime components
* added memory-aware MCP resources
* improved resource response structure and registry-based routing
* added MCP registry tests and updated MCP integration tests

This evolves the MCP layer toward a scalable cognition runtime where tools, resources, memory, permissions, and prompts become composable semantic primitives.
