### PR TITLE
feat(issue-28): implement semantic MCP capability tools

### DIFF
--- a/orchestrator/mcp/models.py
+++ b/orchestrator/mcp/models.py
@@ -1,0 +1,14 @@
+"""Shared MCP semantic capability models."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ToolExecutionResult(BaseModel):
+    success: bool = True
+    capability: str
+    result: Any = None
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    warnings: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/orchestrator/mcp/server.py
+++ b/orchestrator/mcp/server.py
@@ -238,7 +238,10 @@ async def invoke_tool(
             detail=f"Invalid arguments: {exc}",
         )
     result = await meta["handler"](parsed)
-    return {"tool": name, "result": result}
+    return {
+        "tool": name,
+        "execution": (result.model_dump() if hasattr(result, "model_dump") else result),
+    }
 
 
 @router.get("/resources/{uri:path}")

--- a/orchestrator/mcp/tools/db_tools.py
+++ b/orchestrator/mcp/tools/db_tools.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel
 from sqlalchemy import text
 
+from orchestrator.mcp.models import ToolExecutionResult
 from orchestrator.core.database import mysql_session_context
 
 READ_ONLY_SQL_COMMANDS = {"select", "show", "describe", "explain"}
@@ -37,12 +38,23 @@ async def query_mysql_handler(input_data: QueryMySQLInput) -> list[dict[str, Any
     """Execute a read-only SQL query."""
     sql = _normalize_readonly_sql(input_data.sql)
     if sql is None:
-        return [{"error": "Only single read-only SQL statements are allowed"}]
+        return ToolExecutionResult(
+            success=False,
+            capability="query_mysql",
+            warnings=["Only single read-only SQL statements are allowed"],
+        )
 
     async with mysql_session_context() as session:
         result = await session.execute(text(sql))
         rows = result.mappings().all()
-        return [dict(row) for row in rows]
+        return ToolExecutionResult(
+            capability="query_mysql",
+            result=[dict(row) for row in rows],
+            metadata={
+                "readonly": True,
+                "row_count": len(rows),
+            },
+        )
 
 
 async def get_readings_handler(input_data: GetReadingsInput) -> list[dict[str, Any]]:
@@ -56,4 +68,11 @@ async def get_readings_handler(input_data: GetReadingsInput) -> list[dict[str, A
             {"device_id": input_data.device_id, "limit": input_data.limit},
         )
         rows = result.mappings().all()
-        return [dict(row) for row in rows]
+        return ToolExecutionResult(
+            capability="get_readings",
+            result=[dict(row) for row in rows],
+            metadata={
+                "device_id": input_data.device_id,
+                "reading_count": len(rows),
+            },
+        )

--- a/orchestrator/mcp/tools/device_tools.py
+++ b/orchestrator/mcp/tools/device_tools.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from orchestrator.mcp.models import ToolExecutionResult
 from orchestrator.core.database import arcadedb_query
 
 
@@ -31,7 +32,16 @@ async def device_turn_on_handler(input_data: DeviceActionInput) -> dict[str, Any
         f"UPDATE Device SET is_active = true WHERE @rid = '{_device_rid(input_data)}'",
         readonly=False,
     )
-    return {"device_id": input_data.device_id, "state": "on"}
+    return ToolExecutionResult(
+        capability="device_turn_on",
+        result={
+            "device_id": input_data.device_id,
+            "state": "on",
+        },
+        metadata={
+            "device_action": "turn_on",
+        },
+    )
 
 
 async def device_turn_off_handler(input_data: DeviceActionInput) -> dict[str, Any]:
@@ -41,7 +51,16 @@ async def device_turn_off_handler(input_data: DeviceActionInput) -> dict[str, An
         f"UPDATE Device SET is_active = false WHERE @rid = '{_device_rid(input_data)}'",
         readonly=False,
     )
-    return {"device_id": input_data.device_id, "state": "off"}
+    return ToolExecutionResult(
+        capability="device_turn_off",
+        result={
+            "device_id": input_data.device_id,
+            "state": "off",
+        },
+        metadata={
+            "device_action": "turn_off",
+        },
+    )
 
 
 async def device_set_brightness_handler(
@@ -56,10 +75,17 @@ async def device_set_brightness_handler(
         ),
         readonly=False,
     )
-    return {
-        "device_id": input_data.device_id,
-        "brightness": input_data.brightness,
-    }
+    return ToolExecutionResult(
+        capability="device_set_brightness",
+        result={
+            "device_id": input_data.device_id,
+            "brightness": input_data.brightness,
+        },
+        confidence=0.95,
+        metadata={
+            "device_action": "set_brightness",
+        },
+    )
 
 
 async def device_get_status_handler(input_data: DeviceActionInput) -> dict[str, Any]:
@@ -70,5 +96,15 @@ async def device_get_status_handler(input_data: DeviceActionInput) -> dict[str, 
     )
     rows = result.get("result", [])
     if isinstance(rows, list) and rows and isinstance(rows[0], dict):
-        return rows[0]
-    return {"error": "Device not found"}
+        return ToolExecutionResult(
+            capability="device_get_status",
+            result=rows[0],
+            metadata={
+                "device_id": input_data.device_id,
+            },
+        )
+    return ToolExecutionResult(
+        success=False,
+        capability="device_get_status",
+        warnings=["Device not found"],
+    )

--- a/orchestrator/mcp/tools/graph_tools.py
+++ b/orchestrator/mcp/tools/graph_tools.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from orchestrator.mcp.models import ToolExecutionResult
 from orchestrator.core.database import arcadedb_query
 
 READ_ONLY_GRAPH_PREFIXES = {"g.", "select", "match", "traverse"}
@@ -58,9 +59,22 @@ async def query_arcadedb_handler(
 ) -> list[dict[str, Any]]:
     """Execute a read-only ArcadeDB query."""
     if not _is_readonly_graph_query(input_data.query):
-        return [{"error": "Only read-only graph queries are allowed"}]
+        return ToolExecutionResult(
+            success=False,
+            capability="query_arcadedb",
+            warnings=["Only read-only graph queries are allowed"],
+        )
     result = await arcadedb_query(input_data.language, input_data.query)
-    return _result_rows(result)
+    rows = _result_rows(result)
+    return ToolExecutionResult(
+        capability="query_arcadedb",
+        result=rows,
+        metadata={
+            "language": input_data.language,
+            "row_count": len(rows),
+            "readonly": True,
+        },
+    )
 
 
 async def get_device_neighbors_handler(
@@ -72,4 +86,12 @@ async def get_device_neighbors_handler(
         "gremlin",
         f"g.V('{device_id}').bothE().otherV().valueMap(true)",
     )
-    return _result_rows(result)
+    rows = _result_rows(result)
+    return ToolExecutionResult(
+        capability="get_device_neighbors",
+        result=rows,
+        metadata={
+            "device_id": input_data.device_id,
+            "neighbor_count": len(rows),
+        },
+    )

--- a/orchestrator/mcp/tools/ha_tools.py
+++ b/orchestrator/mcp/tools/ha_tools.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 from pydantic import BaseModel
 
+from orchestrator.mcp.models import ToolExecutionResult
 from orchestrator.config import get_settings
 
 settings = get_settings()
@@ -33,22 +34,41 @@ async def ha_get_state_handler(input_data: HAGetStateInput) -> dict[str, Any]:
     """Get current state of a Home Assistant entity."""
     token = settings.HA_TOKEN or os.getenv("HA_TOKEN", "")
     if not token:
-        return {"error": "HA_TOKEN not configured"}
+        return ToolExecutionResult(
+            success=False,
+            capability="ha_get_state",
+            warnings=["HA_TOKEN not configured"],
+        )
     async with httpx.AsyncClient(timeout=10.0) as client:
         response = await client.get(
             f"{settings.HA_URL}/api/states/{input_data.entity_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
         if response.status_code == 200:
-            return _json_object(response)
-        return {"error": f"HA API returned {response.status_code}"}
+            return ToolExecutionResult(
+                capability="ha_get_state",
+                result=_json_object(response),
+                metadata={
+                    "entity_id": input_data.entity_id,
+                    "source": "home_assistant",
+                },
+            )
+        return ToolExecutionResult(
+            success=False,
+            capability="ha_get_state",
+            warnings=[f"HA API returned {response.status_code}"],
+        )
 
 
 async def ha_call_service_handler(input_data: HACallServiceInput) -> dict[str, Any]:
     """Call a Home Assistant service."""
     token = settings.HA_TOKEN or os.getenv("HA_TOKEN", "")
     if not token:
-        return {"error": "HA_TOKEN not configured"}
+        return ToolExecutionResult(
+            success=False,
+            capability="ha_call_service",
+            warnings=["HA_TOKEN not configured"],
+        )
     payload = {"entity_id": input_data.entity_id}
     if input_data.service_data:
         payload.update(input_data.service_data)
@@ -62,5 +82,21 @@ async def ha_call_service_handler(input_data: HACallServiceInput) -> dict[str, A
             json=payload,
         )
         if response.status_code in (200, 201):
-            return {"status": "ok", "response": _json_object(response)}
-        return {"error": f"HA API returned {response.status_code}"}
+            return ToolExecutionResult(
+                capability="ha_call_service",
+                result={
+                    "status": "ok",
+                    "response": _json_object(response),
+                },
+                confidence=0.9,
+                metadata={
+                    "domain": input_data.domain,
+                    "service": input_data.service,
+                    "entity_id": input_data.entity_id,
+                },
+            )
+        return ToolExecutionResult(
+            success=False,
+            capability="ha_call_service",
+            warnings=[f"HA API returned {response.status_code}"],
+        )

--- a/orchestrator/tests/test_e2e_workflow.py
+++ b/orchestrator/tests/test_e2e_workflow.py
@@ -117,9 +117,9 @@ async def test_mocked_homeassistant_state():
             HAGetStateInput(entity_id="light.living_room")
         )
 
-        assert result["state"] == "on"
+        assert result.result["state"] == "on"
 
-        assert result["attributes"]["brightness"] == 255
+        assert result.result["attributes"]["brightness"] == 255
 
 
 @pytest.mark.anyio

--- a/orchestrator/tests/test_mcp.py
+++ b/orchestrator/tests/test_mcp.py
@@ -51,7 +51,13 @@ async def test_invoke_query_mysql(client):
             "query_mysql": {
                 "description": "Test",
                 "input_schema": QueryInput,
-                "handler": AsyncMock(return_value=[{"id": 1}]),
+                "handler": AsyncMock(
+                    return_value={
+                        "success": True,
+                        "capability": "query_mysql",
+                        "result": [{"id": 1}],
+                    }
+                ),
                 "permissions": ["device:read"],
             }
         },
@@ -61,7 +67,7 @@ async def test_invoke_query_mysql(client):
             json={"name": "query_mysql", "arguments": {"sql": "SELECT 1"}},
         )
     assert resp.status_code == 200
-    assert resp.json()["result"] == [{"id": 1}]
+    assert resp.json()["execution"]["result"] == [{"id": 1}]
 
 
 @pytest.mark.anyio

--- a/orchestrator/tests/test_mcp_models.py
+++ b/orchestrator/tests/test_mcp_models.py
@@ -1,0 +1,10 @@
+from orchestrator.mcp.models import ToolExecutionResult
+
+
+def test_tool_execution_result_defaults():
+    result = ToolExecutionResult(
+        capability="test_capability",
+    )
+
+    assert result.success is True
+    assert result.confidence == 1.0


### PR DESCRIPTION
Issue #28 

Implemented typed MCP capability tools with semantic execution envelopes, permission-aware execution, and structured capability metadata.

### Changes

* added shared `ToolExecutionResult` execution model
* updated DB, graph, Home Assistant, and device tools to return structured capability results
* added execution metadata, **confidence scores**, and warning propagation
* improved MCP execution consistency across all tool categories
* updated MCP server execution handling
* added MCP capability model tests and updated integration tests
