### PR TITLE
Add live HA graph sync and BaseAgent execution model

### DIFF
--- a/orchestrator/agents/base.py
+++ b/orchestrator/agents/base.py
@@ -1,50 +1,110 @@
-"""Base agent abstract class."""
+"""Base agent abstract class and shared execution models."""
 
+import json
+import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import Any, List
+from time import monotonic
+from typing import Any
 
+from pydantic import BaseModel, ConfigDict, Field
+
+from orchestrator.core.permissions import AGENT_RUN
 from orchestrator.llm.client import LLMClient
 
+logger = logging.getLogger(__name__)
 
-@dataclass
-class Task:
+Tool = str
+Memory = dict[str, Any]
+
+
+class Task(BaseModel):
     """A task to be processed by an agent."""
 
-    id: str
-    intent: str
-    payload: dict
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = ""
+    intent: str = Field(min_length=1)
+    payload: dict[str, Any] = Field(default_factory=dict)
     user_id: str = ""
-    timeout_seconds: int = 30
+    timeout_seconds: int = Field(default=30, gt=0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class Result:
+class Result(BaseModel):
     """Result of agent task execution."""
 
+    model_config = ConfigDict(extra="forbid")
+
     success: bool
-    data: Any
+    data: Any = None
     message: str = ""
+    agent: str | None = None
+    task_id: str | None = None
+    error: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class Status:
+class Status(BaseModel):
     """Health status of an agent."""
+
+    model_config = ConfigDict(extra="forbid")
 
     healthy: bool
     message: str = ""
+    agent: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
 
 
 class BaseAgent(ABC):
     """Abstract base class for all EcoNest agents."""
 
     name: str = "base"
-    tools: List[str] = field(default_factory=list)
-    permissions: List[str] = field(default_factory=list)
+    tools: list[Tool] = []
+    permissions: list[str] = [AGENT_RUN]
 
-    def __init__(self, llm: LLMClient | None = None):
+    def __init__(
+        self,
+        llm: LLMClient | None = None,
+        memory: Memory | None = None,
+    ) -> None:
         self.llm = llm or LLMClient()
-        self.memory: dict[str, Any] = {}
+        self.memory: Memory = memory or {}
+
+    async def execute(self, task: Task) -> Result:
+        """Run a task with shared capability checks and structured logging."""
+        started_at = monotonic()
+        result: Result
+        try:
+            if not await self.can_handle(task):
+                result = Result(
+                    success=False,
+                    data={},
+                    message=f"{self.name} cannot handle this task",
+                    agent=self.name,
+                    task_id=task.id,
+                    error="unsupported_task",
+                )
+            else:
+                result = await self.run(task)
+                result = result.model_copy(
+                    update={
+                        "agent": result.agent or self.name,
+                        "task_id": result.task_id or task.id,
+                    }
+                )
+        except Exception as exc:
+            result = Result(
+                success=False,
+                data={},
+                message=f"{self.name} failed while running task",
+                agent=self.name,
+                task_id=task.id,
+                error=exc.__class__.__name__,
+                metadata={"error_message": str(exc)},
+            )
+        duration_ms = round((monotonic() - started_at) * 1000, 3)
+        self._log_run(task, result, duration_ms)
+        return result
 
     @abstractmethod
     async def run(self, task: Task) -> Result:
@@ -58,4 +118,29 @@ class BaseAgent(ABC):
 
     async def healthcheck(self) -> Status:
         """Return health status. Subclasses may override."""
-        return Status(healthy=True, message=f"{self.name} is healthy")
+        return Status(
+            healthy=True,
+            message=f"{self.name} is healthy",
+            agent=self.name,
+            details={
+                "tools": list(self.tools),
+                "permissions": list(self.permissions),
+            },
+        )
+
+    def _log_run(self, task: Task, result: Result, duration_ms: float) -> None:
+        event = {
+            "event": "agent.run",
+            "agent": self.name,
+            "task_id": task.id,
+            "intent": task.intent,
+            "user_id": task.user_id,
+            "success": result.success,
+            "message": result.message,
+            "error": result.error,
+            "duration_ms": duration_ms,
+            "tools": list(self.tools),
+            "permissions": list(self.permissions),
+        }
+        log_method = logger.info if result.success else logger.warning
+        log_method(json.dumps(event, sort_keys=True))

--- a/orchestrator/agents/orchestrator.py
+++ b/orchestrator/agents/orchestrator.py
@@ -44,7 +44,7 @@ class AgentOrchestrator:
         for attempt in range(3):
             try:
                 result = await asyncio.wait_for(
-                    agent.run(task),
+                    agent.execute(task),
                     timeout=task.timeout_seconds,
                 )
                 self._results[task.id] = result
@@ -97,5 +97,6 @@ class AgentOrchestrator:
     async def healthcheck(self) -> dict[str, Any]:
         """Healthcheck all registered agents."""
         return {
-            agent.name: (await agent.healthcheck()).__dict__ for agent in self.agents
+            agent.name: (await agent.healthcheck()).model_dump()
+            for agent in self.agents
         }

--- a/orchestrator/graph/relationships.py
+++ b/orchestrator/graph/relationships.py
@@ -279,12 +279,19 @@ async def _sync_observation_sensor_edges() -> int:
 
 async def _sync_user_home_edges() -> int:
     await _clear_edges("OWNS")
-    users = await _graph_rows("g.V().hasLabel('User').values('@rid')")
+    user_result = await arcadedb_query(
+        "sql",
+        "SELECT @rid FROM User WHERE role IN ['homeowner', 'superadmin']",
+    )
+    users = _result_values(user_result)
     home_selector = "(SELECT FROM Home LIMIT 1)"
     if not users or not await _selector_exists(home_selector):
         return 0
     count = 0
-    for user_rid in users:
+    for user in users:
+        if not isinstance(user, Mapping):
+            continue
+        user_rid = user.get("@rid")
         if not isinstance(user_rid, str):
             continue
         await _repair_edge("OWNS", user_rid, home_selector)

--- a/orchestrator/tests/test_agents.py
+++ b/orchestrator/tests/test_agents.py
@@ -1,13 +1,97 @@
 """Tests for agents and orchestrator."""
 
-import pytest
+import json
+import logging
 
-from orchestrator.agents.base import Task
+import pytest
+from pydantic import ValidationError
+
+from orchestrator.agents.base import BaseAgent, Result, Task
 from orchestrator.agents.device_agent import DeviceAgent
 from orchestrator.agents.energy_agent import EnergyAgent
 from orchestrator.agents.orchestrator import AgentOrchestrator
 from orchestrator.agents.security_agent import SecurityAgent
 from orchestrator.agents.sensor_agent import SensorAgent
+
+# ------------------------------------------------------------------
+# Base models and execution
+# ------------------------------------------------------------------
+
+
+class _SuccessAgent(BaseAgent):
+    name = "success"
+    tools = ["test_tool"]
+    permissions = ["agent:run"]
+
+    async def can_handle(self, task: Task) -> bool:
+        return "ok" in task.intent
+
+    async def run(self, task: Task) -> Result:
+        return Result(success=True, data={"handled": task.intent}, message="done")
+
+
+class _FailingAgent(_SuccessAgent):
+    name = "failing"
+
+    async def run(self, task: Task) -> Result:
+        raise RuntimeError("boom")
+
+
+def test_task_validation_rejects_empty_intent():
+    with pytest.raises(ValidationError):
+        Task(id="1", intent="", payload={})
+
+
+def test_task_defaults_are_structured():
+    task = Task(intent="ok task")
+    assert task.id == ""
+    assert task.payload == {}
+    assert task.metadata == {}
+    assert task.timeout_seconds == 30
+
+
+@pytest.mark.anyio
+async def test_base_agent_execute_success_logs_json(caplog):
+    agent = _SuccessAgent()
+    task = Task(id="task-1", intent="ok task", payload={}, user_id="user-1")
+
+    with caplog.at_level(logging.INFO, logger="orchestrator.agents.base"):
+        result = await agent.execute(task)
+
+    assert result.success
+    assert result.agent == "success"
+    assert result.task_id == "task-1"
+
+    event = json.loads(caplog.records[-1].message)
+    assert event["event"] == "agent.run"
+    assert event["agent"] == "success"
+    assert event["task_id"] == "task-1"
+    assert event["success"] is True
+    assert "duration_ms" in event
+
+
+@pytest.mark.anyio
+async def test_base_agent_execute_rejects_unsupported_task():
+    agent = _SuccessAgent()
+    result = await agent.execute(Task(id="task-2", intent="no match", payload={}))
+
+    assert not result.success
+    assert result.agent == "success"
+    assert result.task_id == "task-2"
+    assert result.error == "unsupported_task"
+
+
+@pytest.mark.anyio
+async def test_base_agent_execute_catches_exceptions():
+    agent = _FailingAgent()
+    result = await agent.execute(Task(id="task-3", intent="ok task", payload={}))
+
+    assert not result.success
+    assert result.agent == "failing"
+    assert result.task_id == "task-3"
+    assert result.error == "RuntimeError"
+    assert result.metadata["error_message"] == "boom"
+
 
 # ------------------------------------------------------------------
 # Agent routing

--- a/orchestrator/tests/test_graph.py
+++ b/orchestrator/tests/test_graph.py
@@ -1013,6 +1013,11 @@ async def test_sync_graph_relationships_repairs_inferred_edges():
                     }
                 ]
             }
+        if (
+            language == "sql"
+            and command == "SELECT @rid FROM User WHERE role IN ['homeowner', 'superadmin']"
+        ):
+            return {"result": [{"@rid": "#4:0"}]}
         if language == "sql" and command.startswith("SELECT FROM"):
             return {"result": [{"@rid": "#9:0"}]}
         return {"result": []}


### PR DESCRIPTION
## Summary
- add live Home Assistant to ArcadeDB graph synchronization with relationship inference
- restrict graph ownership edges to homeowner/superadmin roles
- implement issue #29 BaseAgent Pydantic models, shared execution wrapper, health metadata, and structured JSON run logging

## Notes
- ArcadeDB user ownership now avoids granting OWNS edges to guest users
- AgentOrchestrator now routes task execution through BaseAgent.execute()