### PR TITLE
Home Assistant device state verification

### DIFF
--- a/orchestrator/agents/device_agent.py
+++ b/orchestrator/agents/device_agent.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from pydantic import BaseModel
 
 from orchestrator.agents.base import BaseAgent, Result, Task
@@ -12,6 +14,9 @@ from orchestrator.mcp.tools.ha_tools import (
     ha_call_service_handler,
     ha_get_state_handler,
 )
+
+HA_VERIFY_ATTEMPTS = 5
+HA_VERIFY_DELAY_SECONDS = 0.5
 
 
 class DeviceActionRequest(BaseModel):
@@ -360,10 +365,15 @@ class DeviceAgent(BaseAgent):
     ) -> bool:
         if expected_state.startswith("brightness:"):
             return True
-        result = await ha_get_state_handler(HAGetStateInput(entity_id=entity_id))
-        if not result.success or not isinstance(result.result, dict):
-            return False
-        return str(result.result.get("state", "")).lower() == expected_state
+        for attempt in range(HA_VERIFY_ATTEMPTS):
+            result = await ha_get_state_handler(HAGetStateInput(entity_id=entity_id))
+            if result.success and isinstance(result.result, dict):
+                state = str(result.result.get("state", "")).lower()
+                if state == expected_state:
+                    return True
+            if attempt < HA_VERIFY_ATTEMPTS - 1:
+                await asyncio.sleep(HA_VERIFY_DELAY_SECONDS)
+        return False
 
     def _ha_entity_id(self, request: DeviceActionRequest) -> str | None:
         if request.entity_id:

--- a/orchestrator/tests/test_agents.py
+++ b/orchestrator/tests/test_agents.py
@@ -832,6 +832,54 @@ async def test_device_agent_calls_home_assistant_for_entity_id():
 
 
 @pytest.mark.anyio
+async def test_device_agent_retries_home_assistant_state_verification():
+    agent = DeviceAgent()
+
+    with (
+        patch(
+            "orchestrator.agents.device_agent.ha_call_service_handler",
+            new=AsyncMock(
+                return_value=ToolExecutionResult(
+                    capability="ha_call_service",
+                    result={"status": "ok"},
+                )
+            ),
+        ),
+        patch(
+            "orchestrator.agents.device_agent.ha_get_state_handler",
+            new=AsyncMock(
+                side_effect=[
+                    ToolExecutionResult(
+                        capability="ha_get_state",
+                        result={"state": "off"},
+                    ),
+                    ToolExecutionResult(
+                        capability="ha_get_state",
+                        result={"state": "on"},
+                    ),
+                ]
+            ),
+        ) as get_state,
+        patch("orchestrator.agents.device_agent.asyncio.sleep", new=AsyncMock()),
+    ):
+        result = await agent.run(
+            Task(
+                id="dev-ha-retry",
+                intent="turn on kitchen light",
+                payload={
+                    "device_id": "light.kitchen",
+                    "action": "turn_on",
+                },
+            )
+        )
+
+    assert result.success
+    assert result.data["verified"] is True
+    assert result.confidence == 0.95
+    assert get_state.await_count == 2
+
+
+@pytest.mark.anyio
 async def test_device_agent_permission_allowed():
 
     agent = DeviceAgent()


### PR DESCRIPTION
- Added retry-based Home Assistant state verification after device actions.
- Polls HA state up to 5 times before marking a device action unverified.
- Adds regression coverage for delayed HA state propagation.
