### PR TITLE
Add Demo1 frontend and device routing precedence

### DIFF
--- a/orchestrator/agents/orchestrator.py
+++ b/orchestrator/agents/orchestrator.py
@@ -254,6 +254,9 @@ class AgentOrchestrator:
 
     async def _classify_intent(self, task: Task) -> str:
         """Classify intent with rules first and LLM fallback second."""
+        if self._is_device_control_task(task):
+            return "device"
+
         intent_lower = task.intent.lower()
         for category, keywords in INTENT_KEYWORDS.items():
             if any(kw in intent_lower for kw in keywords):

--- a/orchestrator/api/demo.py
+++ b/orchestrator/api/demo.py
@@ -1,0 +1,260 @@
+"""Professor-facing live demo routes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import HTMLResponse, StreamingResponse
+from pydantic import BaseModel
+
+from orchestrator.agents.base import Result, Task
+from orchestrator.agents.orchestrator import AgentOrchestrator
+from orchestrator.core.database import healthcheck_arcadedb, healthcheck_mysql
+from orchestrator.core.permissions import Role
+from orchestrator.mcp.tools.ha_tools import HAGetStateInput, ha_get_state_handler
+
+router = APIRouter(prefix="/demo", tags=["demo"])
+_demo_orchestrator = AgentOrchestrator()
+
+DEMO_ACCESS_CODE = "Demo1"
+DEMO_MEDIA_LIGHT_ENTITY = "light.upstairs_media_light_1"
+DEMO_POLL_INTERVAL_SECONDS = 0.4
+DEMO_MAX_POLLS = 75
+
+
+class DemoRequest(BaseModel):
+    code: str
+
+
+@router.get("", response_class=HTMLResponse)
+async def demo_page() -> HTMLResponse:
+    """Serve the browser demo control surface."""
+    page = Path(__file__).resolve().parents[1] / "static" / "demo.html"
+    return HTMLResponse(page.read_text(encoding="utf-8"))
+
+
+@router.post("/demo1")
+async def run_demo1(req: DemoRequest) -> StreamingResponse:
+    """Run the live Demo1 sequence and stream human-readable progress."""
+    if req.code.strip() != DEMO_ACCESS_CODE:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid demo code",
+        )
+
+    return StreamingResponse(
+        _demo1_events(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+async def _demo1_events() -> AsyncIterator[str]:
+    yield _event(
+        "start",
+        "Demo1 started",
+        "Replaying smart-home events and letting EcoNest route them to agents.",
+    )
+
+    mysql_ok = await healthcheck_mysql()
+    arcade_ok = await healthcheck_arcadedb()
+    yield _event(
+        "health",
+        "Infrastructure check",
+        "MySQL and ArcadeDB are reachable."
+        if mysql_ok and arcade_ok
+        else "One or more infrastructure services are degraded.",
+        {"mysql": mysql_ok, "arcadedb": arcade_ok},
+        ok=mysql_ok and arcade_ok,
+    )
+
+    initial_state = await _read_ha_state(DEMO_MEDIA_LIGHT_ENTITY)
+    yield _event(
+        "home_assistant",
+        "Media room light before event",
+        _state_summary(initial_state),
+        {"entity_id": DEMO_MEDIA_LIGHT_ENTITY, "state": initial_state},
+        ok=bool(initial_state.get("success")),
+    )
+
+    energy_task = Task(
+        intent="energy anomaly detected in media room",
+        payload={
+            "type": "energy",
+            "room": "media room",
+            "device_name": "Media Room Plug",
+            "current_power_w": 650,
+            "baseline_w": 100,
+            "trigger": "Demo1",
+            "user_role": Role.HOMEOWNER.value,
+        },
+        timeout_seconds=30,
+        metadata={
+            "source": "demo_event_replay",
+            "event_type": "energy_anomaly",
+            "user_role": Role.HOMEOWNER.value,
+        },
+    )
+    energy_task_id = await _demo_orchestrator.submit(energy_task)
+    yield _event(
+        "agent",
+        "Energy anomaly submitted",
+        "EcoNest is routing an unusual power spike to the energy agent.",
+        {"task_id": energy_task_id, "intent": energy_task.intent},
+    )
+
+    energy_result = await _wait_for_task(energy_task_id)
+    if energy_result is None:
+        yield _event(
+            "failed",
+            "Energy agent task timed out",
+            "The energy agent did not finish within the demo window.",
+            {"task_id": energy_task_id},
+            ok=False,
+        )
+        return
+
+    yield _event(
+        "agent_result",
+        "Energy agent result",
+        _agent_summary(energy_result),
+        energy_result.model_dump(),
+        ok=energy_result.success,
+    )
+
+    device_task = Task(
+        intent="motion detected in media room, turn on media room light",
+        payload={
+            "event_type": "motion_detected",
+            "room": "media room",
+            "device_id": DEMO_MEDIA_LIGHT_ENTITY,
+            "entity_id": DEMO_MEDIA_LIGHT_ENTITY,
+            "domain": "light",
+            "action": "turn_on",
+            "trigger": "Demo1",
+            "user_role": Role.HOMEOWNER.value,
+        },
+        timeout_seconds=30,
+        metadata={
+            "source": "ha_event_replay",
+            "event_type": "motion_detected",
+            "user_role": Role.HOMEOWNER.value,
+        },
+    )
+    device_task_id = await _demo_orchestrator.submit(device_task)
+    yield _event(
+        "agent",
+        "Motion event submitted",
+        "EcoNest is routing the motion event to the device agent for action.",
+        {"task_id": device_task_id, "intent": device_task.intent},
+    )
+
+    device_result = await _wait_for_task(device_task_id)
+    if device_result is None:
+        yield _event(
+            "failed",
+            "Device agent task timed out",
+            "The device agent did not finish within the demo window.",
+            {"task_id": device_task_id},
+            ok=False,
+        )
+        return
+
+    yield _event(
+        "agent_result",
+        "Device agent result",
+        _agent_summary(device_result),
+        device_result.model_dump(),
+        ok=device_result.success,
+    )
+
+    final_state = await _read_ha_state(DEMO_MEDIA_LIGHT_ENTITY)
+    yield _event(
+        "home_assistant",
+        "Media room light after event",
+        _state_summary(final_state),
+        {"entity_id": DEMO_MEDIA_LIGHT_ENTITY, "state": final_state},
+        ok=bool(final_state.get("success")),
+    )
+
+    yield _event(
+        "complete",
+        "Demo1 complete",
+        "The events were routed through EcoNest and the Home Assistant state was checked.",
+        {
+            "energy_task_id": energy_task_id,
+            "device_task_id": device_task_id,
+            "agents": [
+                agent
+                for agent in (energy_result.agent, device_result.agent)
+                if agent is not None
+            ],
+            "verified": device_result.metadata.get("verified"),
+            "confidence": device_result.confidence,
+        },
+        ok=energy_result.success and device_result.success,
+    )
+
+
+async def _read_ha_state(entity_id: str) -> dict[str, Any]:
+    result = await ha_get_state_handler(HAGetStateInput(entity_id=entity_id))
+    if hasattr(result, "model_dump"):
+        return result.model_dump()
+    return dict(result)
+
+
+async def _wait_for_task(task_id: str) -> Result | None:
+    for _ in range(DEMO_MAX_POLLS):
+        result = await _demo_orchestrator.get_result(task_id)
+        if result is not None:
+            return result
+        await asyncio.sleep(DEMO_POLL_INTERVAL_SECONDS)
+    return None
+
+
+def _event(
+    event_type: str,
+    title: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    ok: bool = True,
+) -> str:
+    payload = {
+        "type": event_type,
+        "title": title,
+        "message": message,
+        "ok": ok,
+        "details": details or {},
+    }
+    return f"data: {json.dumps(payload, default=str)}\n\n"
+
+
+def _state_summary(state_result: dict[str, Any]) -> str:
+    if not state_result.get("success"):
+        warnings = state_result.get("warnings") or ["Home Assistant state unavailable"]
+        return "; ".join(str(warning) for warning in warnings)
+
+    result = state_result.get("result")
+    if not isinstance(result, dict):
+        return "Home Assistant returned a state response."
+
+    entity_id = result.get("entity_id", DEMO_MEDIA_LIGHT_ENTITY)
+    state = result.get("state", "unknown")
+    return f"{entity_id} is currently {state}."
+
+
+def _agent_summary(result: Result) -> str:
+    if not result.success:
+        return result.message or "The selected agent failed to complete the task."
+
+    verified = result.metadata.get("verified")
+    source = result.metadata.get("execution_source", "agent")
+    return (
+        f"{result.agent or 'Agent'} completed the task through {source}; "
+        f"verified={verified}, confidence={result.confidence}."
+    )

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import FastAPI
 
-from orchestrator.api import auth, devices, graph, mcp, ontology, readings, users
+from orchestrator.api import auth, demo, devices, graph, mcp, ontology, readings, users
 from orchestrator.config import get_settings
 from orchestrator.core.database import (
     close_databases,
@@ -36,6 +36,7 @@ app = FastAPI(
 
 
 app.include_router(auth.router)
+app.include_router(demo.router)
 app.include_router(devices.router)
 app.include_router(graph.router)
 app.include_router(mcp.router)

--- a/orchestrator/static/demo.html
+++ b/orchestrator/static/demo.html
@@ -1,0 +1,514 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EcoNest Demo Console</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #1d2420;
+        --muted: #5b6760;
+        --line: #d8ded9;
+        --panel: #ffffff;
+        --bg: #f4f7f3;
+        --green: #1d7a46;
+        --red: #b42318;
+        --gold: #9a6700;
+        --blue: #245cc0;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+      }
+
+      main {
+        width: min(1120px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 28px 0 40px;
+      }
+
+      header {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 20px;
+        padding-bottom: 18px;
+        border-bottom: 1px solid var(--line);
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(28px, 4vw, 48px);
+        line-height: 1;
+        letter-spacing: 0;
+      }
+
+      .subtitle {
+        margin: 10px 0 0;
+        color: var(--muted);
+        max-width: 720px;
+        font-size: 15px;
+        line-height: 1.45;
+      }
+
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 34px;
+        padding: 7px 11px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        background: var(--panel);
+        color: var(--muted);
+        font-size: 13px;
+        white-space: nowrap;
+      }
+
+      .dot {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: var(--gold);
+      }
+
+      .dot.running {
+        background: var(--blue);
+      }
+
+      .dot.good {
+        background: var(--green);
+      }
+
+      .dot.bad {
+        background: var(--red);
+      }
+
+      .controls {
+        display: grid;
+        grid-template-columns: minmax(220px, 1fr) auto;
+        gap: 12px;
+        align-items: end;
+        margin: 26px 0;
+      }
+
+      label {
+        display: grid;
+        gap: 7px;
+        color: var(--muted);
+        font-size: 13px;
+        font-weight: 600;
+      }
+
+      input {
+        width: 100%;
+        min-height: 46px;
+        border: 1px solid #bfc8c1;
+        border-radius: 6px;
+        padding: 0 13px;
+        color: var(--ink);
+        background: var(--panel);
+        font: inherit;
+        font-size: 16px;
+      }
+
+      input:focus {
+        border-color: var(--blue);
+        outline: 3px solid rgba(36, 92, 192, 0.16);
+      }
+
+      button {
+        min-width: 150px;
+        min-height: 46px;
+        border: 0;
+        border-radius: 6px;
+        background: var(--ink);
+        color: white;
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.55;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: 300px minmax(0, 1fr);
+        gap: 18px;
+      }
+
+      .summary,
+      .timeline {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+      }
+
+      .summary {
+        align-self: start;
+        padding: 18px;
+      }
+
+      .summary h2,
+      .timeline h2 {
+        margin: 0;
+        font-size: 17px;
+        letter-spacing: 0;
+      }
+
+      .metric {
+        display: grid;
+        gap: 5px;
+        padding: 15px 0;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .metric:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+
+      .metric span {
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+
+      .metric strong {
+        overflow-wrap: anywhere;
+        font-size: 17px;
+      }
+
+      .timeline {
+        min-height: 480px;
+        overflow: hidden;
+      }
+
+      .timeline-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 18px;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .events {
+        display: grid;
+        gap: 0;
+      }
+
+      .event {
+        display: grid;
+        grid-template-columns: 28px minmax(0, 1fr);
+        gap: 12px;
+        padding: 16px 18px;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .event:last-child {
+        border-bottom: 0;
+      }
+
+      .event-marker {
+        width: 16px;
+        height: 16px;
+        margin-top: 3px;
+        border: 2px solid var(--blue);
+        border-radius: 50%;
+      }
+
+      .event.ok .event-marker {
+        border-color: var(--green);
+        background: rgba(29, 122, 70, 0.12);
+      }
+
+      .event.fail .event-marker {
+        border-color: var(--red);
+        background: rgba(180, 35, 24, 0.12);
+      }
+
+      .event h3 {
+        margin: 0;
+        font-size: 16px;
+        letter-spacing: 0;
+      }
+
+      .event p {
+        margin: 6px 0 10px;
+        color: var(--muted);
+        line-height: 1.45;
+      }
+
+      details {
+        width: 100%;
+      }
+
+      summary {
+        cursor: pointer;
+        color: var(--blue);
+        font-size: 13px;
+        font-weight: 700;
+      }
+
+      pre {
+        overflow-x: auto;
+        margin: 10px 0 0;
+        padding: 12px;
+        border-radius: 6px;
+        background: #101614;
+        color: #e8eee9;
+        font-size: 12px;
+        line-height: 1.5;
+      }
+
+      .empty {
+        padding: 42px 18px;
+        color: var(--muted);
+        text-align: center;
+      }
+
+      @media (max-width: 820px) {
+        header,
+        .controls,
+        .grid {
+          grid-template-columns: 1fr;
+        }
+
+        header {
+          align-items: start;
+        }
+
+        .status-pill {
+          justify-self: start;
+        }
+
+        button {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <h1>EcoNest Demo Console</h1>
+          <p class="subtitle">
+            Trigger Demo1 and watch EcoNest inspect Home Assistant, route a smart-home
+            event to the correct agent, act on the media room light, and verify the
+            result.
+          </p>
+        </div>
+        <div class="status-pill" aria-live="polite">
+          <span id="statusDot" class="dot"></span>
+          <span id="statusText">Ready</span>
+        </div>
+      </header>
+
+      <form id="demoForm" class="controls">
+        <label>
+          Demo code
+          <input
+            id="demoCode"
+            name="code"
+            autocomplete="off"
+            spellcheck="false"
+            placeholder="Demo1"
+            required
+          />
+        </label>
+        <button id="runButton" type="submit">Run Demo</button>
+      </form>
+
+      <section class="grid">
+        <aside class="summary">
+          <h2>Live Summary</h2>
+          <div class="metric">
+            <span>Backend</span>
+            <strong id="backend">Detecting</strong>
+          </div>
+          <div class="metric">
+            <span>Current stage</span>
+            <strong id="stage">Waiting</strong>
+          </div>
+          <div class="metric">
+            <span>Selected agent</span>
+            <strong id="agent">Not selected</strong>
+          </div>
+          <div class="metric">
+            <span>Verification</span>
+            <strong id="verification">Pending</strong>
+          </div>
+          <div class="metric">
+            <span>Confidence</span>
+            <strong id="confidence">Pending</strong>
+          </div>
+        </aside>
+
+        <section class="timeline" aria-live="polite">
+          <div class="timeline-head">
+            <h2>Execution Timeline</h2>
+          </div>
+          <div id="events" class="events">
+            <div class="empty">Enter the demo code and run the sequence.</div>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <script>
+      const form = document.getElementById("demoForm");
+      const code = document.getElementById("demoCode");
+      const button = document.getElementById("runButton");
+      const events = document.getElementById("events");
+      const statusDot = document.getElementById("statusDot");
+      const statusText = document.getElementById("statusText");
+      const stage = document.getElementById("stage");
+      const agent = document.getElementById("agent");
+      const verification = document.getElementById("verification");
+      const confidence = document.getElementById("confidence");
+      const backend = document.getElementById("backend");
+      const apiBase = resolveApiBase();
+
+      if (shouldRedirectToBackend(apiBase)) {
+        window.location.replace(`${apiBase}/demo`);
+      }
+
+      backend.textContent = apiBase;
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        resetRun();
+        setStatus("running", "Running");
+        button.disabled = true;
+
+        try {
+          const response = await fetch(`${apiBase}/demo/demo1`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ code: code.value }),
+          });
+
+          if (!response.ok || !response.body) {
+            const text = await response.text();
+            throw new Error(text || `Request failed with ${response.status}`);
+          }
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
+
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const chunks = buffer.split("\n\n");
+            buffer = chunks.pop() || "";
+            chunks.forEach(parseEvent);
+          }
+
+          setStatus(statusDot.classList.contains("bad") ? "bad" : "good", "Finished");
+        } catch (error) {
+          addEvent({
+            title: "Demo request failed",
+            message: error.message,
+            ok: false,
+            details: {},
+          });
+          setStatus("bad", "Failed");
+        } finally {
+          button.disabled = false;
+        }
+      });
+
+      function parseEvent(chunk) {
+        const line = chunk
+          .split("\n")
+          .find((item) => item.startsWith("data: "));
+        if (!line) return;
+        addEvent(JSON.parse(line.slice(6)));
+      }
+
+      function addEvent(event) {
+        if (events.querySelector(".empty")) events.innerHTML = "";
+
+        const item = document.createElement("article");
+        item.className = `event ${event.ok ? "ok" : "fail"}`;
+        item.innerHTML = `
+          <div class="event-marker"></div>
+          <div>
+            <h3></h3>
+            <p></p>
+            <details>
+              <summary>View details</summary>
+              <pre></pre>
+            </details>
+          </div>
+        `;
+        item.querySelector("h3").textContent = event.title;
+        item.querySelector("p").textContent = event.message;
+        item.querySelector("pre").textContent = JSON.stringify(event.details, null, 2);
+        events.appendChild(item);
+        item.scrollIntoView({ block: "nearest", behavior: "smooth" });
+
+        stage.textContent = event.title;
+        if (!event.ok) setStatus("bad", "Needs attention");
+
+        const details = event.details || {};
+        if (details.agent) agent.textContent = details.agent;
+        if (details.verified !== undefined) verification.textContent = String(details.verified);
+        if (details.confidence !== undefined) confidence.textContent = String(details.confidence);
+      }
+
+      function resetRun() {
+        events.innerHTML = '<div class="empty">Starting Demo1...</div>';
+        stage.textContent = "Starting";
+        agent.textContent = "Not selected";
+        verification.textContent = "Pending";
+        confidence.textContent = "Pending";
+      }
+
+      function setStatus(kind, text) {
+        statusDot.className = `dot ${kind}`;
+        statusText.textContent = text;
+      }
+
+      function resolveApiBase() {
+        const { protocol, hostname, port, origin } = window.location;
+        if ((protocol === "http:" || protocol === "https:") && port === "8001") {
+          return origin;
+        }
+
+        if (!hostname || hostname === "localhost" || hostname === "127.0.0.1") {
+          return "http://127.0.0.1:8001";
+        }
+
+        return `${protocol || "http:"}//${hostname}:8001`;
+      }
+
+      function shouldRedirectToBackend(apiBase) {
+        if (window.location.protocol !== "http:" && window.location.protocol !== "https:") {
+          return true;
+        }
+
+        return window.location.origin !== apiBase;
+      }
+    </script>
+  </body>
+</html>

--- a/orchestrator/tests/test_agents.py
+++ b/orchestrator/tests/test_agents.py
@@ -361,6 +361,25 @@ async def test_orchestrator_routes_device():
 
 
 @pytest.mark.anyio
+async def test_orchestrator_routes_device_action_before_motion_security():
+    orch = AgentOrchestrator()
+    task = Task(
+        id="",
+        intent="motion detected in media room, turn on media room light",
+        payload={
+            "action": "turn_on",
+            "domain": "light",
+            "device_id": "light.upstairs_media_light_1",
+        },
+    )
+
+    agent = await orch._classify_and_route(task)
+
+    assert agent is not None
+    assert agent.name == "device"
+
+
+@pytest.mark.anyio
 async def test_orchestrator_healthcheck():
     orch = AgentOrchestrator()
     health = await orch.healthcheck()

--- a/orchestrator/tests/test_demo.py
+++ b/orchestrator/tests/test_demo.py
@@ -1,0 +1,87 @@
+"""Tests for the browser demo flow."""
+
+from unittest.mock import AsyncMock
+
+from orchestrator.agents.base import Result
+from orchestrator.api import demo
+from orchestrator.mcp.models import ToolExecutionResult
+
+
+def test_demo_page_serves_frontend(client):
+    response = client.get("/demo")
+
+    assert response.status_code == 200
+    assert "EcoNest Demo Console" in response.text
+    assert "Demo1" in response.text
+
+
+def test_demo1_rejects_invalid_code(client):
+    response = client.post("/demo/demo1", json={"code": "wrong"})
+
+    assert response.status_code == 403
+
+
+def test_demo1_streams_readable_progress(client, monkeypatch):
+    class FakeOrchestrator:
+        async def submit(self, task):
+            if task.payload.get("type") == "energy":
+                assert task.metadata["event_type"] == "energy_anomaly"
+                return "task-energy-1"
+            assert task.payload["action"] == "turn_on"
+            assert task.metadata["source"] == "ha_event_replay"
+            return "task-device-1"
+
+        async def get_result(self, task_id):
+            if task_id == "task-energy-1":
+                return Result(
+                    success=True,
+                    data={
+                        "recommendation": "Shift media room load to off-peak hours",
+                    },
+                    message="Energy review complete",
+                    agent="energy",
+                    task_id=task_id,
+                    confidence=1.0,
+                )
+            assert task_id == "task-device-1"
+            return Result(
+                success=True,
+                data={
+                    "action": "turn_on",
+                    "verified": True,
+                    "execution_source": "home_assistant",
+                },
+                message="Device action completed",
+                agent="device",
+                task_id=task_id,
+                confidence=0.95,
+                metadata={
+                    "verified": True,
+                    "execution_source": "home_assistant",
+                },
+            )
+
+    ha_state = ToolExecutionResult(
+        capability="ha_get_state",
+        result={
+            "entity_id": demo.DEMO_MEDIA_LIGHT_ENTITY,
+            "state": "on",
+        },
+    )
+
+    monkeypatch.setattr(demo, "healthcheck_mysql", AsyncMock(return_value=True))
+    monkeypatch.setattr(demo, "healthcheck_arcadedb", AsyncMock(return_value=True))
+    monkeypatch.setattr(demo, "ha_get_state_handler", AsyncMock(return_value=ha_state))
+    monkeypatch.setattr(demo, "_demo_orchestrator", FakeOrchestrator())
+
+    response = client.post("/demo/demo1", json={"code": "Demo1"})
+
+    assert response.status_code == 200
+    assert "Demo1 started" in response.text
+    assert "Infrastructure check" in response.text
+    assert "Energy agent result" in response.text
+    assert "Device agent result" in response.text
+    assert "Demo1 complete" in response.text
+    assert '"agent": "energy"' in response.text
+    assert '"agent": "device"' in response.text
+    assert '"verified": true' in response.text


### PR DESCRIPTION
- Added a browser-based `/demo` console for Demo1 runs.
- Added a streaming `/demo/demo1` endpoint that emits readable progress events while the demo runs.
- Demo1 now checks infrastructure, reads the media room light state, routes an energy anomaly to the energy agent, routes a motion/light event to the device agent, and verifies Home Assistant state afterward.
- Updated agent routing so explicit device-control payloads route to the device agent before generic security keywords like `motion`.
- Added regression coverage for the motion-plus-turn-on routing case.
- Added demo route tests for page loading, invalid demo code rejection, and streamed progress output.