### PR TITLE
Add LLM feedback and thermostat demo support

### DIFF
--- a/orchestrator/agents/device_agent.py
+++ b/orchestrator/agents/device_agent.py
@@ -23,6 +23,7 @@ class DeviceActionRequest(BaseModel):
     device_id: str
     action: str | None = None
     brightness: int | None = None
+    temperature: float | None = None
     domain: str | None = None
     entity_id: str | None = None
 
@@ -90,6 +91,9 @@ class DeviceAgent(BaseAgent):
             ),
             brightness=task.payload.get(
                 "brightness",
+            ),
+            temperature=task.payload.get(
+                "temperature",
             ),
             domain=task.payload.get(
                 "domain",
@@ -190,6 +194,7 @@ class DeviceAgent(BaseAgent):
             "turn_on": "OnOff",
             "turn_off": "OnOff",
             "set_brightness": "Dimmable",
+            "set_temperature": "Thermostat",
         }
 
         required = required_capabilities.get(request.action)
@@ -322,6 +327,14 @@ class DeviceAgent(BaseAgent):
                 verified=True,
             )
 
+        if request.action == "set_temperature":
+            return DeviceExecution(
+                success=True,
+                state=f"target_temperature:{request.temperature}",
+                source="local_fallback",
+                verified=True,
+            )
+
         raise ValueError(f"Unsupported action: {request.action}")
 
     async def _execute_home_assistant_action(
@@ -365,6 +378,22 @@ class DeviceAgent(BaseAgent):
     ) -> bool:
         if expected_state.startswith("brightness:"):
             return True
+        if expected_state.startswith("target_temperature:"):
+            expected_temperature = float(expected_state.split(":", 1)[1])
+            for attempt in range(HA_VERIFY_ATTEMPTS):
+                result = await ha_get_state_handler(HAGetStateInput(entity_id=entity_id))
+                if result.success and isinstance(result.result, dict):
+                    attributes = result.result.get("attributes", {})
+                    if isinstance(attributes, dict):
+                        observed = attributes.get("temperature")
+                        if (
+                            observed is not None
+                            and abs(float(observed) - expected_temperature) < 0.1
+                        ):
+                            return True
+                if attempt < HA_VERIFY_ATTEMPTS - 1:
+                    await asyncio.sleep(HA_VERIFY_DELAY_SECONDS)
+            return False
         for attempt in range(HA_VERIFY_ATTEMPTS):
             result = await ha_get_state_handler(HAGetStateInput(entity_id=entity_id))
             if result.success and isinstance(result.result, dict):
@@ -389,14 +418,20 @@ class DeviceAgent(BaseAgent):
             return "turn_off"
         if request.action == "set_brightness":
             return "turn_on"
+        if request.action == "set_temperature":
+            return "set_temperature"
         raise ValueError(f"Unsupported action: {request.action}")
 
     def _ha_service_data(self, request: DeviceActionRequest) -> dict | None:
-        if request.action != "set_brightness":
-            return None
-        if request.brightness is None:
-            return None
-        return {"brightness_pct": request.brightness}
+        if request.action == "set_brightness":
+            if request.brightness is None:
+                return None
+            return {"brightness_pct": request.brightness}
+        if request.action == "set_temperature":
+            if request.temperature is None:
+                return None
+            return {"temperature": request.temperature}
+        return None
 
     def _expected_state(self, request: DeviceActionRequest) -> str:
         if request.action == "turn_on":
@@ -405,4 +440,6 @@ class DeviceAgent(BaseAgent):
             return "off"
         if request.action == "set_brightness":
             return f"brightness:{request.brightness}"
+        if request.action == "set_temperature":
+            return f"target_temperature:{request.temperature}"
         return "unknown"

--- a/orchestrator/agents/orchestrator.py
+++ b/orchestrator/agents/orchestrator.py
@@ -21,12 +21,15 @@ from orchestrator.llm.models import LLMMessage
 MAX_RETRIES = 3
 NIGHT_CONTROL_START_HOUR = 23
 NIGHT_CONTROL_END_HOUR = 6
+MIN_LLM_CLASSIFICATION_CONFIDENCE = 0.45
 
 
 class IntentClassification(BaseModel):
-    """LLM fallback output for intent routing."""
+    """LLM output for intent routing."""
 
     category: str = Field(pattern="^(energy|security|sensor|device|multi|unknown)$")
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    reasoning: str = ""
 
 
 INTENT_KEYWORDS: dict[str, tuple[str, ...]] = {
@@ -253,33 +256,53 @@ class AgentOrchestrator:
         return []
 
     async def _classify_intent(self, task: Task) -> str:
-        """Classify intent with rules first and LLM fallback second."""
-        if self._is_device_control_task(task):
-            return "device"
+        """Classify intent with LLM first and deterministic rules as fallback."""
+        llm_category = await self._classify_intent_with_llm(task)
+        if llm_category != "unknown":
+            return llm_category
 
-        intent_lower = task.intent.lower()
-        for category, keywords in INTENT_KEYWORDS.items():
-            if any(kw in intent_lower for kw in keywords):
-                return category
+        return self._classify_intent_with_rules(task)
 
+    async def _classify_intent_with_llm(self, task: Task) -> str:
+        """Use the local LLM as the primary intent classifier."""
         try:
             classification = await self.llm.generate_structured(
                 [
                     LLMMessage(
                         role="user",
                         content=(
-                            "Classify this smart-home task into one category: "
-                            "energy, security, sensor, device, multi, or unknown.\n"
-                            f"Intent: {task.intent}\nPayload: {task.payload}"
+                            "Classify this smart-home task into exactly one category: "
+                            "energy, security, sensor, device, multi, or unknown.\n\n"
+                            "Use the payload as the strongest signal. "
+                            "If the payload asks for a concrete device action such as "
+                            "turn_on, turn_off, set_brightness, open, close, or includes "
+                            "a controllable domain like light or switch, classify it as "
+                            "device even if the text also mentions motion or security.\n\n"
+                            f"Intent: {task.intent}\n"
+                            f"Payload: {task.payload}\n"
+                            f"Metadata: {task.metadata}"
                         ),
                     )
                 ],
                 IntentClassification,
                 temperature=0.0,
             )
-            return classification.category
         except Exception:
             return "unknown"
+
+        if classification.confidence < MIN_LLM_CLASSIFICATION_CONFIDENCE:
+            return "unknown"
+        return classification.category
+
+    def _classify_intent_with_rules(self, task: Task) -> str:
+        """Deterministic fallback when LLM classification is unavailable."""
+        if self._is_device_control_task(task):
+            return "device"
+        intent_lower = task.intent.lower()
+        for category, keywords in INTENT_KEYWORDS.items():
+            if any(kw in intent_lower for kw in keywords):
+                return category
+        return "unknown"
 
     async def _agent_for_category(
         self,

--- a/orchestrator/api/demo.py
+++ b/orchestrator/api/demo.py
@@ -4,31 +4,66 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
+import httpx
 from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import HTMLResponse, StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from orchestrator.agents.base import Result, Task
 from orchestrator.agents.orchestrator import AgentOrchestrator
+from orchestrator.config import get_settings
 from orchestrator.core.database import healthcheck_arcadedb, healthcheck_mysql
 from orchestrator.core.permissions import Role
+from orchestrator.llm.client import LLMClient
+from orchestrator.llm.models import LLMMessage
 from orchestrator.mcp.tools.ha_tools import HAGetStateInput, ha_get_state_handler
 
 router = APIRouter(prefix="/demo", tags=["demo"])
+settings = get_settings()
 _demo_orchestrator = AgentOrchestrator()
+_feedback_memory: dict[str, Any] = {
+    "last_occupancy": None,
+    "transitions": [],
+    "observation_count": 0,
+}
 
 DEMO_ACCESS_CODE = "Demo1"
+DEMO2_ACCESS_CODE = "Demo2"
 DEMO_MEDIA_LIGHT_ENTITY = "light.upstairs_media_light_1"
+DEMO_MEDIA_THERMOSTAT_ENTITY = "climate.media_room"
+DEMO_MEDIA_TEMPERATURE_SENSOR = "sensor.media_room_temperature"
+DEMO_MEDIA_HUMIDITY_SENSOR = "sensor.media_room_humidity"
 DEMO_POLL_INTERVAL_SECONDS = 0.4
 DEMO_MAX_POLLS = 75
+DEMO_THERMOSTAT_MIN_SETPOINT = 74.0
+DEMO_THERMOSTAT_MAX_SETPOINT = 80.0
 
 
 class DemoRequest(BaseModel):
     code: str
+
+
+class ThermostatReasoning(BaseModel):
+    summary: str
+    recommended_temperature: float = Field(ge=60.0, le=90.0)
+    rationale: str
+
+
+class FeedbackSuggestion(BaseModel):
+    category: str = Field(pattern="^(energy|security|occupancy|comfort)$")
+    priority: str = Field(pattern="^(LOW|MEDIUM|HIGH)$")
+    title: str
+    detail: str
+
+
+class PeriodicFeedback(BaseModel):
+    summary: str
+    suggestions: list[FeedbackSuggestion] = Field(default_factory=list)
 
 
 @router.get("", response_class=HTMLResponse)
@@ -52,6 +87,38 @@ async def run_demo1(req: DemoRequest) -> StreamingResponse:
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+
+
+@router.post("/demo2")
+async def run_demo2(req: DemoRequest) -> StreamingResponse:
+    """Run the thermostat-focused Demo2 sequence."""
+    if req.code.strip() != DEMO2_ACCESS_CODE:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid demo code",
+        )
+
+    return StreamingResponse(
+        _demo2_events(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.get("/feedback")
+async def periodic_feedback() -> dict[str, Any]:
+    """Return passive LLM-backed household feedback without taking actions."""
+    states = await _read_all_ha_states()
+    snapshot = _build_household_feedback_snapshot(states)
+    feedback = await _llm_periodic_feedback(snapshot)
+    return {
+        "mode": "suggestions_only",
+        "source": feedback["source"],
+        "warning": feedback["warning"],
+        "summary": feedback["summary"],
+        "suggestions": feedback["suggestions"],
+        "snapshot": snapshot,
+    }
 
 
 async def _demo1_events() -> AsyncIterator[str]:
@@ -183,21 +250,246 @@ async def _demo1_events() -> AsyncIterator[str]:
     )
 
     yield _event(
+        "occupancy",
+        "Vacancy timeout detected",
+        "Simulated follow-up event: 10 minutes pass with no media room motion.",
+        {
+            "room": "media room",
+            "occupancy_signal": "no_motion_for_10_minutes",
+            "policy": "vacant rooms should not keep nonessential lights on",
+        },
+    )
+
+    reasoning = await _llm_light_policy_reasoning(final_state)
+    yield _event(
+        "llm_reasoning",
+        "LLM policy reasoning",
+        reasoning["summary"],
+        reasoning,
+        ok=reasoning["source"] == "ollama",
+    )
+
+    off_task_id: str | None = None
+    off_result: Result | None = None
+    off_state: dict[str, Any] | None = None
+    if reasoning["recommended_action"] == "turn_off":
+        off_task = Task(
+            intent="room is vacant, turn off media room light",
+            payload={
+                "event_type": "occupancy_cleared",
+                "room": "media room",
+                "device_id": DEMO_MEDIA_LIGHT_ENTITY,
+                "entity_id": DEMO_MEDIA_LIGHT_ENTITY,
+                "domain": "light",
+                "action": "turn_off",
+                "trigger": "Demo1",
+                "user_role": Role.HOMEOWNER.value,
+            },
+            timeout_seconds=30,
+            metadata={
+                "source": "llm_policy_recommendation",
+                "event_type": "occupancy_cleared",
+                "user_role": Role.HOMEOWNER.value,
+            },
+        )
+        off_task_id = await _demo_orchestrator.submit(off_task)
+        yield _event(
+            "agent",
+            "Policy action submitted",
+            "EcoNest is routing the LLM recommendation to the device agent.",
+            {"task_id": off_task_id, "intent": off_task.intent},
+        )
+
+        off_result = await _wait_for_task(off_task_id)
+        if off_result is None:
+            yield _event(
+                "failed",
+                "Policy action timed out",
+                "The device agent did not finish the turn-off action within the demo window.",
+                {"task_id": off_task_id},
+                ok=False,
+            )
+            return
+
+        yield _event(
+            "agent_result",
+            "Policy action result",
+            _agent_summary(off_result),
+            off_result.model_dump(),
+            ok=off_result.success,
+        )
+
+        off_state = await _read_ha_state(DEMO_MEDIA_LIGHT_ENTITY)
+        yield _event(
+            "home_assistant",
+            "Media room light after policy action",
+            _state_summary(off_state),
+            {"entity_id": DEMO_MEDIA_LIGHT_ENTITY, "state": off_state},
+            ok=bool(off_state.get("success")),
+        )
+
+    yield _event(
         "complete",
         "Demo1 complete",
-        "The events were routed through EcoNest and the Home Assistant state was checked.",
+        "The events were routed through EcoNest, LLM reasoning was shown, and Home Assistant state was checked.",
         {
             "energy_task_id": energy_task_id,
             "device_task_id": device_task_id,
+            "policy_task_id": off_task_id,
             "agents": [
                 agent
-                for agent in (energy_result.agent, device_result.agent)
+                for agent in (
+                    energy_result.agent,
+                    device_result.agent,
+                    off_result.agent if off_result else None,
+                )
                 if agent is not None
             ],
-            "verified": device_result.metadata.get("verified"),
-            "confidence": device_result.confidence,
+            "llm_source": reasoning["source"],
+            "recommended_action": reasoning["recommended_action"],
+            "verified": (
+                off_result.metadata.get("verified")
+                if off_result
+                else device_result.metadata.get("verified")
+            ),
+            "confidence": off_result.confidence if off_result else device_result.confidence,
+            "final_state": _ha_state_value(off_state or final_state),
         },
-        ok=energy_result.success and device_result.success,
+        ok=energy_result.success
+        and device_result.success
+        and (off_result.success if off_result else True),
+    )
+
+
+async def _demo2_events() -> AsyncIterator[str]:
+    yield _event(
+        "start",
+        "Demo2 started",
+        "Reading the media room thermostat and asking Ollama to reason about comfort and energy.",
+    )
+
+    mysql_ok = await healthcheck_mysql()
+    arcade_ok = await healthcheck_arcadedb()
+    yield _event(
+        "health",
+        "Infrastructure check",
+        "MySQL and ArcadeDB are reachable."
+        if mysql_ok and arcade_ok
+        else "One or more infrastructure services are degraded.",
+        {"mysql": mysql_ok, "arcadedb": arcade_ok},
+        ok=mysql_ok and arcade_ok,
+    )
+
+    thermostat_state = await _read_ha_state(DEMO_MEDIA_THERMOSTAT_ENTITY)
+    temperature_state = await _read_ha_state(DEMO_MEDIA_TEMPERATURE_SENSOR)
+    humidity_state = await _read_ha_state(DEMO_MEDIA_HUMIDITY_SENSOR)
+    yield _event(
+        "home_assistant",
+        "Media room climate snapshot",
+        _climate_snapshot_summary(
+            thermostat_state,
+            temperature_state,
+            humidity_state,
+        ),
+        {
+            "thermostat": thermostat_state,
+            "temperature_sensor": temperature_state,
+            "humidity_sensor": humidity_state,
+        },
+        ok=bool(thermostat_state.get("success")),
+    )
+
+    reasoning = await _llm_thermostat_reasoning(
+        thermostat_state,
+        temperature_state,
+        humidity_state,
+    )
+    yield _event(
+        "llm_reasoning",
+        "Thermostat LLM reasoning",
+        reasoning["summary"],
+        reasoning,
+        ok=reasoning["source"] in {"ollama", "policy_guarded_ollama"},
+    )
+
+    setpoint = reasoning["bounded_temperature"]
+    climate_task = Task(
+        intent="adjust media room thermostat based on comfort and energy reasoning",
+        payload={
+            "event_type": "comfort_energy_review",
+            "room": "media room",
+            "device_id": DEMO_MEDIA_THERMOSTAT_ENTITY,
+            "entity_id": DEMO_MEDIA_THERMOSTAT_ENTITY,
+            "domain": "climate",
+            "action": "set_temperature",
+            "temperature": setpoint,
+            "trigger": "Demo2",
+            "user_role": Role.HOMEOWNER.value,
+        },
+        timeout_seconds=30,
+        metadata={
+            "source": "llm_climate_recommendation",
+            "event_type": "comfort_energy_review",
+            "user_role": Role.HOMEOWNER.value,
+        },
+    )
+    climate_task_id = await _demo_orchestrator.submit(climate_task)
+    yield _event(
+        "agent",
+        "Thermostat action submitted",
+        "EcoNest is routing the bounded LLM recommendation to the device agent.",
+        {"task_id": climate_task_id, "intent": climate_task.intent},
+    )
+
+    climate_result = await _wait_for_task(climate_task_id)
+    if climate_result is None:
+        yield _event(
+            "failed",
+            "Thermostat action timed out",
+            "The device agent did not finish the thermostat action within the demo window.",
+            {"task_id": climate_task_id},
+            ok=False,
+        )
+        return
+
+    yield _event(
+        "agent_result",
+        "Thermostat action result",
+        _agent_summary(climate_result),
+        climate_result.model_dump(),
+        ok=climate_result.success,
+    )
+
+    updated_thermostat_state = await _read_ha_state(DEMO_MEDIA_THERMOSTAT_ENTITY)
+    yield _event(
+        "home_assistant",
+        "Media room thermostat after action",
+        _thermostat_target_summary(updated_thermostat_state),
+        {
+            "entity_id": DEMO_MEDIA_THERMOSTAT_ENTITY,
+            "state": updated_thermostat_state,
+        },
+        ok=bool(updated_thermostat_state.get("success")),
+    )
+
+    yield _event(
+        "complete",
+        "Demo2 complete",
+        "Ollama reasoned over the climate context, EcoNest bounded the recommendation, and the device agent applied it through Home Assistant.",
+        {
+            "task_id": climate_task_id,
+            "agents": ["llm", climate_result.agent],
+            "llm_source": reasoning["source"],
+            "recommended_temperature": reasoning["recommended_temperature"],
+            "bounded_temperature": setpoint,
+            "verified": climate_result.metadata.get("verified"),
+            "confidence": climate_result.confidence,
+            "final_target_temperature": _ha_attribute_value(
+                updated_thermostat_state,
+                "temperature",
+            ),
+        },
+        ok=climate_result.success,
     )
 
 
@@ -208,6 +500,20 @@ async def _read_ha_state(entity_id: str) -> dict[str, Any]:
     return dict(result)
 
 
+async def _read_all_ha_states() -> list[dict[str, Any]]:
+    token = settings.HA_TOKEN or os.getenv("HA_TOKEN", "")
+    if not token:
+        return []
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.get(
+            f"{settings.HA_URL}/api/states",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+    data = response.json()
+    return data if isinstance(data, list) else []
+
+
 async def _wait_for_task(task_id: str) -> Result | None:
     for _ in range(DEMO_MAX_POLLS):
         result = await _demo_orchestrator.get_result(task_id)
@@ -215,6 +521,479 @@ async def _wait_for_task(task_id: str) -> Result | None:
             return result
         await asyncio.sleep(DEMO_POLL_INTERVAL_SECONDS)
     return None
+
+
+def _build_household_feedback_snapshot(states: list[dict[str, Any]]) -> dict[str, Any]:
+    people = [
+        _entity_summary(item)
+        for item in states
+        if str(item.get("entity_id", "")).startswith(("person.", "device_tracker."))
+    ]
+    occupancy_status = _occupancy_status(people)
+    transition = _record_occupancy_observation(occupancy_status)
+
+    lights_on = [
+        _entity_summary(item)
+        for item in states
+        if str(item.get("entity_id", "")).startswith("light.")
+        and str(item.get("state", "")).lower() == "on"
+    ]
+    switches_on = [
+        _entity_summary(item)
+        for item in states
+        if str(item.get("entity_id", "")).startswith("switch.")
+        and str(item.get("state", "")).lower() == "on"
+    ]
+    covers_open = [
+        _entity_summary(item)
+        for item in states
+        if str(item.get("entity_id", "")).startswith("cover.")
+        and str(item.get("state", "")).lower() not in {"closed", "closing"}
+    ]
+    active_motion = [
+        _entity_summary(item)
+        for item in states
+        if str(item.get("entity_id", "")).startswith("binary_sensor.")
+        and "motion" in _entity_text(item)
+        and str(item.get("state", "")).lower() == "on"
+    ]
+    power_now = sorted(
+        [
+            _numeric_sensor_summary(item)
+            for item in states
+            if "power_minute_average" in str(item.get("entity_id", ""))
+        ],
+        key=lambda item: item["value"],
+        reverse=True,
+    )[:8]
+    energy_today = sorted(
+        [
+            _numeric_sensor_summary(item)
+            for item in states
+            if "energy_today" in str(item.get("entity_id", ""))
+        ],
+        key=lambda item: item["value"],
+        reverse=True,
+    )[:8]
+
+    return {
+        "occupancy_status": occupancy_status,
+        "occupancy_transition": transition,
+        "observation_count": _feedback_memory["observation_count"],
+        "recent_occupancy_transitions": list(_feedback_memory["transitions"][-5:]),
+        "people": people[:10],
+        "lights_on": lights_on[:15],
+        "switches_on": switches_on[:15],
+        "covers_open": covers_open,
+        "active_motion": active_motion,
+        "top_power_now_w": power_now,
+        "top_energy_today_kwh": energy_today,
+    }
+
+
+async def _llm_periodic_feedback(snapshot: dict[str, Any]) -> dict[str, Any]:
+    prompt = (
+        "You are EcoNest's passive home advisor. Review this Home Assistant snapshot "
+        "and produce suggestion-only feedback. Do not tell the system to take actions. "
+        "Focus on energy waste, security awareness, occupancy patterns, and comfort.\n\n"
+        f"Snapshot JSON:\n{json.dumps(snapshot, default=str)}\n\n"
+        "Return concise suggestions a resident could choose to do manually. "
+        "Mention occupancy transitions if useful. Prefer JSON with summary and suggestions, "
+        "but plain text bullets are acceptable. Only use entities and facts present "
+        "in the snapshot. Do not invent examples, pets, passwords, biometric security, "
+        "or generic cybersecurity advice."
+    )
+    client = LLMClient()
+    try:
+        raw = await client.generate(
+            prompt,
+            system="You produce passive smart-home suggestions. Never issue commands.",
+            temperature=0.2,
+        )
+        result = _periodic_feedback_from_text(raw, snapshot)
+        source = "ollama"
+        warning = None
+    except Exception as exc:
+        result = _fallback_periodic_feedback(snapshot)
+        source = "fallback"
+        warning = str(exc)
+    finally:
+        await client.close()
+
+    observed = _fallback_periodic_feedback(snapshot).suggestions
+    combined = _merge_feedback_suggestions(observed, result.suggestions)
+    suggestions = [item.model_dump() for item in combined[:6]]
+    return {
+        "source": source,
+        "warning": warning,
+        "summary": result.summary,
+        "suggestions": suggestions,
+    }
+
+
+def _periodic_feedback_from_text(text: str, snapshot: dict[str, Any]) -> PeriodicFeedback:
+    cleaned = _clean_jsonish_text(text)
+    try:
+        return PeriodicFeedback.model_validate_json(cleaned)
+    except Exception:
+        pass
+
+    lines = [
+        line.strip(" -*0123456789.").strip()
+        for line in text.splitlines()
+        if line.strip()
+    ]
+    suggestion_lines = [
+        line
+        for line in lines
+        if len(line) > 20
+        and not line.lower().startswith(("summary", "here"))
+        and _is_grounded_feedback_line(line)
+    ][:6]
+    suggestions = [
+        FeedbackSuggestion(
+            category=_infer_feedback_category(line),
+            priority=_infer_feedback_priority(line),
+            title=_clean_feedback_line(line)[:70],
+            detail=_clean_feedback_line(line),
+        )
+        for line in suggestion_lines
+    ]
+    if not suggestions:
+        return _fallback_periodic_feedback(snapshot)
+    return PeriodicFeedback(
+        summary=(
+            f"House appears {snapshot['occupancy_status']}; Ollama generated "
+            "suggestion-only feedback from the latest Home Assistant snapshot."
+        ),
+        suggestions=suggestions,
+    )
+
+
+def _clean_jsonish_text(text: str) -> str:
+    cleaned = text.strip()
+    if cleaned.startswith("```json"):
+        cleaned = cleaned[7:]
+    if cleaned.startswith("```"):
+        cleaned = cleaned[3:]
+    if cleaned.endswith("```"):
+        cleaned = cleaned[:-3]
+    return cleaned.strip()
+
+
+def _infer_feedback_category(text: str) -> str:
+    lowered = text.lower()
+    if any(word in lowered for word in ("door", "garage", "lock", "security", "motion")):
+        return "security"
+    if any(word in lowered for word in ("home", "away", "resident", "occupancy")):
+        return "occupancy"
+    if any(word in lowered for word in ("temperature", "humidity", "comfort")):
+        return "comfort"
+    return "energy"
+
+
+def _is_grounded_feedback_line(text: str) -> bool:
+    lowered = text.lower()
+    banned = (
+        "[example]",
+        "password",
+        "biometric",
+        "pet",
+        "animal",
+        "sensitive information",
+        "enable authentication",
+    )
+    return not any(term in lowered for term in banned)
+
+
+def _clean_feedback_line(text: str) -> str:
+    return (
+        text.replace("**", "")
+        .replace("[Example]:", "")
+        .replace("Example:", "")
+        .strip(" :-")
+    )
+
+
+def _infer_feedback_priority(text: str) -> str:
+    lowered = text.lower()
+    if any(word in lowered for word in ("urgent", "high", "open", "away")):
+        return "HIGH"
+    if any(word in lowered for word in ("review", "consider", "reduce", "highest")):
+        return "MEDIUM"
+    return "LOW"
+
+
+def _fallback_periodic_feedback(snapshot: dict[str, Any]) -> PeriodicFeedback:
+    suggestions: list[FeedbackSuggestion] = []
+    if snapshot["occupancy_status"] == "away" and snapshot["lights_on"]:
+        suggestions.append(
+            FeedbackSuggestion(
+                category="energy",
+                priority="HIGH",
+                title="Lights are on while the house appears away",
+                detail=(
+                    "Consider checking the listed lights when convenient, especially "
+                    "if nobody is home."
+                ),
+            )
+        )
+    for top in snapshot["top_power_now_w"][:3]:
+        suggestions.append(
+            FeedbackSuggestion(
+                category="energy",
+                priority="MEDIUM",
+                title=f"Review current load: {top['name']}",
+                detail=(
+                    f"{top['name']} is reading about {top['value']:.1f} W. "
+                    "If this is unexpected, it may be worth reviewing."
+                ),
+            )
+        )
+    for light in snapshot["lights_on"][:3]:
+        suggestions.append(
+            FeedbackSuggestion(
+                category="energy",
+                priority="LOW",
+                title=f"Light currently on: {light['name']}",
+                detail=(
+                    f"{light['name']} is on while the house appears "
+                    f"{snapshot['occupancy_status']}. Consider turning it off if the "
+                    "room is not being used."
+                ),
+            )
+        )
+    if snapshot["covers_open"]:
+        suggestions.append(
+            FeedbackSuggestion(
+                category="security",
+                priority="HIGH",
+                title="A garage or cover is not closed",
+                detail="Check open covers before leaving or going to sleep.",
+            )
+        )
+    if snapshot["occupancy_transition"]:
+        suggestions.append(
+            FeedbackSuggestion(
+                category="occupancy",
+                priority="LOW",
+                title="Occupancy pattern changed",
+                detail=(
+                    f"EcoNest observed a transition from "
+                    f"{snapshot['occupancy_transition']['from']} to "
+                    f"{snapshot['occupancy_transition']['to']}."
+                ),
+            )
+        )
+    if not suggestions:
+        suggestions.append(
+            FeedbackSuggestion(
+                category="energy",
+                priority="LOW",
+                title="No urgent issues detected",
+                detail="Current energy and security signals look normal.",
+            )
+        )
+    return PeriodicFeedback(
+        summary=(
+            f"House appears {snapshot['occupancy_status']}; generated "
+            "suggestion-only feedback from the latest Home Assistant snapshot."
+        ),
+        suggestions=suggestions,
+    )
+
+
+def _merge_feedback_suggestions(
+    observed: list[FeedbackSuggestion],
+    llm: list[FeedbackSuggestion],
+) -> list[FeedbackSuggestion]:
+    merged: list[FeedbackSuggestion] = []
+    seen: set[str] = set()
+    for suggestion in [*observed, *llm]:
+        key = suggestion.title.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(suggestion)
+    return merged
+
+
+async def _llm_thermostat_reasoning(
+    thermostat_state: dict[str, Any],
+    temperature_state: dict[str, Any],
+    humidity_state: dict[str, Any],
+) -> dict[str, Any]:
+    current_temperature = _float_or_none(_ha_state_value(temperature_state))
+    current_humidity = _float_or_none(_ha_state_value(humidity_state))
+    current_target = _float_or_none(_ha_attribute_value(thermostat_state, "temperature"))
+    hvac_mode = _ha_state_value(thermostat_state)
+
+    prompt = (
+        "You are EcoNest's local smart-home climate reasoning model. "
+        "Recommend one thermostat setpoint for a live demo.\n\n"
+        "Context:\n"
+        "- Room: media room\n"
+        f"- Thermostat entity: {DEMO_MEDIA_THERMOSTAT_ENTITY}\n"
+        f"- HVAC mode: {hvac_mode}\n"
+        f"- Current room temperature: {current_temperature} F\n"
+        f"- Current thermostat target: {current_target} F\n"
+        f"- Current humidity: {current_humidity}%\n"
+        "- Scenario: the room is occupied for a study/demo session, but EcoNest should avoid aggressive cooling.\n"
+        f"- Demo safety range: {DEMO_THERMOSTAT_MIN_SETPOINT}-{DEMO_THERMOSTAT_MAX_SETPOINT} F.\n\n"
+        "Return JSON only. Recommend a comfortable but energy-aware target temperature "
+        "inside the demo safety range."
+    )
+    client = LLMClient()
+    try:
+        result = await client.generate_structured(
+            [
+                LLMMessage(
+                    role="user",
+                    content=prompt,
+                )
+            ],
+            ThermostatReasoning,
+            temperature=0.2,
+        )
+        source = "ollama"
+        warning = None
+    except Exception as exc:
+        result = ThermostatReasoning(
+            summary=(
+                "The media room is warm, so EcoNest should choose a moderate "
+                "cooling target instead of an aggressive setpoint."
+            ),
+            recommended_temperature=78.0,
+            rationale="Fallback policy selected a conservative comfort setpoint.",
+        )
+        source = "fallback"
+        warning = str(exc)
+    finally:
+        await client.close()
+
+    bounded = _bounded_temperature(result.recommended_temperature)
+    summary = result.summary.strip() or result.rationale.strip()
+    if bounded != result.recommended_temperature:
+        source = "policy_guarded_ollama" if source == "ollama" else source
+        summary = (
+            f"{summary} EcoNest bounded the setpoint to {bounded:g} F for the demo."
+        )
+
+    return {
+        "agent": "llm",
+        "source": source,
+        "summary": summary,
+        "rationale": result.rationale,
+        "hvac_mode": hvac_mode,
+        "current_temperature": current_temperature,
+        "current_humidity": current_humidity,
+        "current_target_temperature": current_target,
+        "recommended_temperature": result.recommended_temperature,
+        "bounded_temperature": bounded,
+        "warning": warning,
+    }
+
+
+async def _llm_light_policy_reasoning(
+    light_state: dict[str, Any],
+) -> dict[str, Any]:
+    state = _ha_state_value(light_state)
+    recommended_action = "turn_off" if state == "on" else "none"
+    prompt = (
+        "You are EcoNest's local smart-home reasoning model. "
+        "Explain this policy decision in exactly two short sentences for a live class demo.\n\n"
+        "Context:\n"
+        "- Room: media room\n"
+        f"- Home Assistant light entity: {DEMO_MEDIA_LIGHT_ENTITY}\n"
+        f"- Current light state: {state}\n"
+        "- New event: 10 minutes have passed since the motion event\n"
+        "- Current occupancy signal: no motion for 10 minutes, so the room is considered vacant\n"
+        "- Energy policy: if a room is vacant and a nonessential light is on, "
+        "recommend turning it off.\n\n"
+        f"Required decision: {recommended_action}. "
+        "If the required decision is turn_off, say the light should be off. "
+        "Do not mention implementation details."
+    )
+    client = LLMClient()
+    try:
+        response = await client.generate(
+            prompt,
+            system="You produce concise smart-home reasoning for EcoNest demos.",
+            temperature=0.2,
+            max_retries=1,
+        )
+    except Exception as exc:
+        response = (
+            "The media room is vacant and the light is nonessential, so the light "
+            "should be turned off to save energy."
+        )
+        source = "fallback"
+        warning = str(exc)
+    else:
+        source = "ollama"
+        warning = None
+    finally:
+        await client.close()
+
+    raw_reasoning = response.strip()
+    reasoning = _guard_light_policy_reasoning(
+        raw_reasoning,
+        state,
+        recommended_action,
+    )
+    if reasoning != raw_reasoning and source == "ollama":
+        source = "policy_guarded_ollama"
+        warning = "Ollama response contradicted the required policy decision."
+
+    return {
+        "agent": "llm",
+        "source": source,
+        "model_reasoning": raw_reasoning,
+        "summary": reasoning,
+        "observed_state": state,
+        "recommended_action": recommended_action,
+        "warning": warning,
+    }
+
+
+def _guard_light_policy_reasoning(
+    reasoning: str,
+    state: str,
+    recommended_action: str,
+) -> str:
+    fallback = (
+        "The media room is now considered vacant, and the nonessential light is "
+        f"currently {state}. EcoNest should turn it off to avoid wasting energy."
+    )
+    if not reasoning:
+        return fallback
+
+    normalized = reasoning.lower()
+    says_keep_on = any(
+        phrase in normalized
+        for phrase in (
+            "remain on",
+            "stay on",
+            "keep on",
+            "keep the light on",
+            "should be on",
+            "should remain on",
+        )
+    )
+    says_turn_off = any(
+        phrase in normalized
+        for phrase in (
+            "turn it off",
+            "turn off",
+            "should be off",
+            "switch it off",
+            "shut off",
+        )
+    )
+
+    if recommended_action == "turn_off" and (says_keep_on or not says_turn_off):
+        return fallback
+    return reasoning
 
 
 def _event(
@@ -248,6 +1027,63 @@ def _state_summary(state_result: dict[str, Any]) -> str:
     return f"{entity_id} is currently {state}."
 
 
+def _climate_snapshot_summary(
+    thermostat_state: dict[str, Any],
+    temperature_state: dict[str, Any],
+    humidity_state: dict[str, Any],
+) -> str:
+    hvac_mode = _ha_state_value(thermostat_state)
+    current_temperature = _ha_state_value(temperature_state)
+    humidity = _ha_state_value(humidity_state)
+    target = _ha_attribute_value(thermostat_state, "temperature")
+    return (
+        f"Media room is {current_temperature} F with {humidity}% humidity; "
+        f"thermostat is {hvac_mode} with target {target} F."
+    )
+
+
+def _thermostat_target_summary(state_result: dict[str, Any]) -> str:
+    target = _ha_attribute_value(state_result, "temperature")
+    hvac_mode = _ha_state_value(state_result)
+    return f"{DEMO_MEDIA_THERMOSTAT_ENTITY} is {hvac_mode} with target {target} F."
+
+
+def _ha_state_value(state_result: dict[str, Any] | None) -> str:
+    if not state_result:
+        return "unknown"
+    result = state_result.get("result")
+    if not isinstance(result, dict):
+        return "unknown"
+    return str(result.get("state", "unknown"))
+
+
+def _ha_attribute_value(state_result: dict[str, Any] | None, key: str) -> Any:
+    if not state_result:
+        return None
+    result = state_result.get("result")
+    if not isinstance(result, dict):
+        return None
+    attributes = result.get("attributes")
+    if not isinstance(attributes, dict):
+        return None
+    return attributes.get(key)
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bounded_temperature(value: float) -> float:
+    bounded = max(
+        DEMO_THERMOSTAT_MIN_SETPOINT,
+        min(DEMO_THERMOSTAT_MAX_SETPOINT, float(value)),
+    )
+    return round(bounded, 1)
+
+
 def _agent_summary(result: Result) -> str:
     if not result.success:
         return result.message or "The selected agent failed to complete the task."
@@ -258,3 +1094,55 @@ def _agent_summary(result: Result) -> str:
         f"{result.agent or 'Agent'} completed the task through {source}; "
         f"verified={verified}, confidence={result.confidence}."
     )
+
+
+def _entity_summary(item: dict[str, Any]) -> dict[str, Any]:
+    attributes = item.get("attributes")
+    if not isinstance(attributes, dict):
+        attributes = {}
+    return {
+        "entity_id": item.get("entity_id"),
+        "name": attributes.get("friendly_name") or item.get("entity_id"),
+        "state": item.get("state"),
+    }
+
+
+def _numeric_sensor_summary(item: dict[str, Any]) -> dict[str, Any]:
+    summary = _entity_summary(item)
+    summary["value"] = _float_or_none(item.get("state")) or 0.0
+    return summary
+
+
+def _entity_text(item: dict[str, Any]) -> str:
+    attributes = item.get("attributes")
+    if not isinstance(attributes, dict):
+        attributes = {}
+    return f"{item.get('entity_id', '')} {attributes.get('friendly_name', '')}".lower()
+
+
+def _occupancy_status(people: list[dict[str, Any]]) -> str:
+    if not people:
+        return "unknown"
+    if any(str(person.get("state", "")).lower() == "home" for person in people):
+        return "home"
+    if all(
+        str(person.get("state", "")).lower() in {"not_home", "away"}
+        for person in people
+    ):
+        return "away"
+    return "mixed"
+
+
+def _record_occupancy_observation(status: str) -> dict[str, Any] | None:
+    previous = _feedback_memory.get("last_occupancy")
+    _feedback_memory["observation_count"] = int(_feedback_memory["observation_count"]) + 1
+    _feedback_memory["last_occupancy"] = status
+    if previous is None or previous == status:
+        return None
+    transition = {
+        "from": previous,
+        "to": status,
+        "observation": _feedback_memory["observation_count"],
+    }
+    _feedback_memory["transitions"].append(transition)
+    return transition

--- a/orchestrator/static/demo.html
+++ b/orchestrator/static/demo.html
@@ -152,7 +152,8 @@
       }
 
       .summary,
-      .timeline {
+      .timeline,
+      .feedback {
         border: 1px solid var(--line);
         border-radius: 8px;
         background: var(--panel);
@@ -283,6 +284,79 @@
         text-align: center;
       }
 
+      .feedback {
+        margin-top: 18px;
+        padding: 18px;
+      }
+
+      .feedback-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+        margin-bottom: 14px;
+      }
+
+      .feedback-head h2 {
+        margin: 0;
+        font-size: 17px;
+      }
+
+      .secondary {
+        min-width: 112px;
+        min-height: 36px;
+        border: 1px solid var(--line);
+        background: var(--panel);
+        color: var(--ink);
+        font-size: 13px;
+      }
+
+      .feedback-summary {
+        margin: 0 0 12px;
+        color: var(--muted);
+        line-height: 1.45;
+      }
+
+      .suggestions {
+        display: grid;
+        gap: 10px;
+      }
+
+      .suggestion {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 12px;
+        background: #fbfcfb;
+      }
+
+      .suggestion h3 {
+        margin: 0 0 6px;
+        font-size: 15px;
+      }
+
+      .suggestion p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.4;
+      }
+
+      .tagline {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-bottom: 8px;
+      }
+
+      .tag {
+        border-radius: 999px;
+        padding: 3px 7px;
+        background: #edf2ee;
+        color: var(--muted);
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+
       @media (max-width: 820px) {
         header,
         .controls,
@@ -310,9 +384,9 @@
         <div>
           <h1>EcoNest Demo Console</h1>
           <p class="subtitle">
-            Trigger Demo1 and watch EcoNest inspect Home Assistant, route a smart-home
-            event to the correct agent, act on the media room light, and verify the
-            result.
+            Trigger Demo1 or Demo2 and watch EcoNest inspect Home Assistant, route
+            smart-home events to agents, reason with the local model, act through
+            Home Assistant, and verify the result.
           </p>
         </div>
         <div class="status-pill" aria-live="polite">
@@ -370,6 +444,19 @@
           </div>
         </section>
       </section>
+
+      <section class="feedback" aria-live="polite">
+        <div class="feedback-head">
+          <h2>Periodic Feedback</h2>
+          <button id="feedbackButton" class="secondary" type="button">Refresh</button>
+        </div>
+        <p id="feedbackSummary" class="feedback-summary">
+          Suggestion-only feedback will appear here. EcoNest will not take actions from this panel.
+        </p>
+        <div id="suggestions" class="suggestions">
+          <div class="empty">Waiting for feedback refresh.</div>
+        </div>
+      </section>
     </main>
 
     <script>
@@ -384,6 +471,9 @@
       const verification = document.getElementById("verification");
       const confidence = document.getElementById("confidence");
       const backend = document.getElementById("backend");
+      const feedbackButton = document.getElementById("feedbackButton");
+      const feedbackSummary = document.getElementById("feedbackSummary");
+      const suggestions = document.getElementById("suggestions");
       const apiBase = resolveApiBase();
 
       if (shouldRedirectToBackend(apiBase)) {
@@ -391,6 +481,9 @@
       }
 
       backend.textContent = apiBase;
+      feedbackButton.addEventListener("click", refreshFeedback);
+      window.setTimeout(refreshFeedback, 800);
+      window.setInterval(refreshFeedback, 120000);
 
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
@@ -399,7 +492,8 @@
         button.disabled = true;
 
         try {
-          const response = await fetch(`${apiBase}/demo/demo1`, {
+          const demoPath = resolveDemoPath(code.value);
+          const response = await fetch(`${apiBase}${demoPath}`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ code: code.value }),
@@ -477,7 +571,7 @@
       }
 
       function resetRun() {
-        events.innerHTML = '<div class="empty">Starting Demo1...</div>';
+        events.innerHTML = `<div class="empty">Starting ${code.value.trim() || "demo"}...</div>`;
         stage.textContent = "Starting";
         agent.textContent = "Not selected";
         verification.textContent = "Pending";
@@ -508,6 +602,56 @@
         }
 
         return window.location.origin !== apiBase;
+      }
+
+      function resolveDemoPath(value) {
+        const normalized = value.trim().toLowerCase();
+        if (normalized === "demo2") return "/demo/demo2";
+        return "/demo/demo1";
+      }
+
+      async function refreshFeedback() {
+        feedbackButton.disabled = true;
+        try {
+          const response = await fetch(`${apiBase}/demo/feedback`);
+          if (!response.ok) throw new Error(`Feedback failed with ${response.status}`);
+          const data = await response.json();
+          renderFeedback(data);
+        } catch (error) {
+          feedbackSummary.textContent = error.message;
+          suggestions.innerHTML = '<div class="empty">Feedback unavailable.</div>';
+        } finally {
+          feedbackButton.disabled = false;
+        }
+      }
+
+      function renderFeedback(data) {
+        feedbackSummary.textContent = `${data.summary} Reasoning: ${data.source || "unknown"}.`;
+        suggestions.innerHTML = "";
+        const items = data.suggestions || [];
+        if (!items.length) {
+          suggestions.innerHTML = '<div class="empty">No suggestions right now.</div>';
+          return;
+        }
+
+        items.forEach((item) => {
+          const card = document.createElement("article");
+          card.className = "suggestion";
+          card.innerHTML = `
+            <div class="tagline">
+              <span class="tag"></span>
+              <span class="tag"></span>
+            </div>
+            <h3></h3>
+            <p></p>
+          `;
+          const tags = card.querySelectorAll(".tag");
+          tags[0].textContent = item.category || "feedback";
+          tags[1].textContent = item.priority || "LOW";
+          card.querySelector("h3").textContent = item.title || "Suggestion";
+          card.querySelector("p").textContent = item.detail || "";
+          suggestions.appendChild(card);
+        });
       }
     </script>
   </body>

--- a/orchestrator/tests/test_agents.py
+++ b/orchestrator/tests/test_agents.py
@@ -81,8 +81,9 @@ class _FlakyAgent(_StaticAgent):
 
 
 class _FakeLLM:
-    def __init__(self, category: str) -> None:
+    def __init__(self, category: str, confidence: float = 1.0) -> None:
         self.category = category
+        self.confidence = confidence
         self.messages: list[Any] = []
 
     async def generate_structured(
@@ -93,7 +94,18 @@ class _FakeLLM:
         temperature: float = 0.7,
     ) -> Any:
         self.messages = messages
-        return output_model(category=self.category)
+        return output_model(category=self.category, confidence=self.confidence)
+
+
+class _FailingClassifierLLM:
+    async def generate_structured(
+        self,
+        messages: list[Any],
+        output_model: type[Any],
+        system: str | None = None,
+        temperature: float = 0.7,
+    ) -> Any:
+        raise RuntimeError("LLM unavailable")
 
 
 async def _wait_for_result(orch: AgentOrchestrator, task_id: str) -> Result | None:
@@ -380,6 +392,44 @@ async def test_orchestrator_routes_device_action_before_motion_security():
 
 
 @pytest.mark.anyio
+async def test_orchestrator_uses_llm_classification_before_rules():
+    llm = _FakeLLM("security")
+    orch = AgentOrchestrator(
+        agents=[_StaticAgent("energy"), _StaticAgent("security")],
+        llm=llm,
+    )
+    task = Task(id="", intent="check my power usage", payload={})
+
+    agent = await orch._classify_and_route(task)
+
+    assert agent is not None
+    assert agent.name == "security"
+    assert llm.messages
+
+
+@pytest.mark.anyio
+async def test_orchestrator_falls_back_to_rules_when_llm_fails():
+    orch = AgentOrchestrator(llm=_FailingClassifierLLM())
+    task = Task(id="", intent="check my power usage", payload={})
+
+    agent = await orch._classify_and_route(task)
+
+    assert agent is not None
+    assert agent.name == "energy"
+
+
+@pytest.mark.anyio
+async def test_orchestrator_falls_back_to_rules_for_low_confidence_llm():
+    orch = AgentOrchestrator(llm=_FakeLLM("security", confidence=0.2))
+    task = Task(id="", intent="turn off the bedroom light", payload={})
+
+    agent = await orch._classify_and_route(task)
+
+    assert agent is not None
+    assert agent.name == "device"
+
+
+@pytest.mark.anyio
 async def test_orchestrator_healthcheck():
     orch = AgentOrchestrator()
     health = await orch.healthcheck()
@@ -403,7 +453,7 @@ async def test_orchestrator_submit_and_result():
 @pytest.mark.anyio
 async def test_orchestrator_http_api_intake_adds_source_and_role():
     agent = _StaticAgent("energy")
-    orch = AgentOrchestrator(agents=[agent])
+    orch = AgentOrchestrator(agents=[agent], llm=_FailingClassifierLLM())
 
     task_id = await orch.submit_http_api(
         intent="energy overview",
@@ -421,7 +471,7 @@ async def test_orchestrator_http_api_intake_adds_source_and_role():
 @pytest.mark.anyio
 async def test_orchestrator_scheduled_intake_adds_source():
     agent = _StaticAgent("energy")
-    orch = AgentOrchestrator(agents=[agent])
+    orch = AgentOrchestrator(agents=[agent], llm=_FailingClassifierLLM())
 
     task_id = await orch.submit_scheduled(
         intent="energy check",
@@ -438,7 +488,7 @@ async def test_orchestrator_scheduled_intake_adds_source():
 @pytest.mark.anyio
 async def test_orchestrator_ha_webhook_intake_adds_source():
     agent = _StaticAgent("security")
-    orch = AgentOrchestrator(agents=[agent])
+    orch = AgentOrchestrator(agents=[agent], llm=_FailingClassifierLLM())
 
     task_id = await orch.submit_home_assistant_webhook(
         event_type="motion alert",
@@ -896,6 +946,55 @@ async def test_device_agent_retries_home_assistant_state_verification():
     assert result.data["verified"] is True
     assert result.confidence == 0.95
     assert get_state.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_device_agent_sets_home_assistant_temperature():
+    agent = DeviceAgent()
+
+    with (
+        patch(
+            "orchestrator.agents.device_agent.ha_call_service_handler",
+            new=AsyncMock(
+                return_value=ToolExecutionResult(
+                    capability="ha_call_service",
+                    result={"status": "ok"},
+                )
+            ),
+        ) as call_service,
+        patch(
+            "orchestrator.agents.device_agent.ha_get_state_handler",
+            new=AsyncMock(
+                return_value=ToolExecutionResult(
+                    capability="ha_get_state",
+                    result={"attributes": {"temperature": 78.0}},
+                )
+            ),
+        ),
+    ):
+        result = await agent.run(
+            Task(
+                id="dev-temp",
+                intent="set media room thermostat",
+                payload={
+                    "device_id": "climate.media_room",
+                    "entity_id": "climate.media_room",
+                    "domain": "climate",
+                    "action": "set_temperature",
+                    "temperature": 78.0,
+                },
+            )
+        )
+
+    assert result.success
+    assert result.data["state"] == "target_temperature:78.0"
+    assert result.data["execution_source"] == "home_assistant"
+    assert result.data["verified"] is True
+    service_input = call_service.await_args.args[0]
+    assert service_input.domain == "climate"
+    assert service_input.service == "set_temperature"
+    assert service_input.entity_id == "climate.media_room"
+    assert service_input.service_data == {"temperature": 78.0}
 
 
 @pytest.mark.anyio

--- a/orchestrator/tests/test_demo.py
+++ b/orchestrator/tests/test_demo.py
@@ -21,15 +21,24 @@ def test_demo1_rejects_invalid_code(client):
     assert response.status_code == 403
 
 
+def test_demo2_rejects_invalid_code(client):
+    response = client.post("/demo/demo2", json={"code": "wrong"})
+
+    assert response.status_code == 403
+
+
 def test_demo1_streams_readable_progress(client, monkeypatch):
     class FakeOrchestrator:
         async def submit(self, task):
             if task.payload.get("type") == "energy":
                 assert task.metadata["event_type"] == "energy_anomaly"
                 return "task-energy-1"
-            assert task.payload["action"] == "turn_on"
-            assert task.metadata["source"] == "ha_event_replay"
-            return "task-device-1"
+            if task.payload["action"] == "turn_on":
+                assert task.metadata["source"] == "ha_event_replay"
+                return "task-device-1"
+            assert task.payload["action"] == "turn_off"
+            assert task.metadata["source"] == "llm_policy_recommendation"
+            return "task-policy-1"
 
         async def get_result(self, task_id):
             if task_id == "task-energy-1":
@@ -42,6 +51,23 @@ def test_demo1_streams_readable_progress(client, monkeypatch):
                     agent="energy",
                     task_id=task_id,
                     confidence=1.0,
+                )
+            if task_id == "task-policy-1":
+                return Result(
+                    success=True,
+                    data={
+                        "action": "turn_off",
+                        "verified": True,
+                        "execution_source": "home_assistant",
+                    },
+                    message="Device action completed",
+                    agent="device",
+                    task_id=task_id,
+                    confidence=0.95,
+                    metadata={
+                        "verified": True,
+                        "execution_source": "home_assistant",
+                    },
                 )
             assert task_id == "task-device-1"
             return Result(
@@ -61,6 +87,16 @@ def test_demo1_streams_readable_progress(client, monkeypatch):
                 },
             )
 
+    class FakeLLMClient:
+        async def generate(self, *args, **kwargs):
+            return (
+                "The media room is vacant and the light is still on. "
+                "EcoNest should turn it off to avoid wasting energy."
+            )
+
+        async def close(self):
+            return None
+
     ha_state = ToolExecutionResult(
         capability="ha_get_state",
         result={
@@ -72,6 +108,7 @@ def test_demo1_streams_readable_progress(client, monkeypatch):
     monkeypatch.setattr(demo, "healthcheck_mysql", AsyncMock(return_value=True))
     monkeypatch.setattr(demo, "healthcheck_arcadedb", AsyncMock(return_value=True))
     monkeypatch.setattr(demo, "ha_get_state_handler", AsyncMock(return_value=ha_state))
+    monkeypatch.setattr(demo, "LLMClient", FakeLLMClient)
     monkeypatch.setattr(demo, "_demo_orchestrator", FakeOrchestrator())
 
     response = client.post("/demo/demo1", json={"code": "Demo1"})
@@ -81,7 +118,180 @@ def test_demo1_streams_readable_progress(client, monkeypatch):
     assert "Infrastructure check" in response.text
     assert "Energy agent result" in response.text
     assert "Device agent result" in response.text
+    assert "LLM policy reasoning" in response.text
+    assert "Policy action result" in response.text
     assert "Demo1 complete" in response.text
     assert '"agent": "energy"' in response.text
     assert '"agent": "device"' in response.text
+    assert '"agent": "llm"' in response.text
+    assert '"recommended_action": "turn_off"' in response.text
     assert '"verified": true' in response.text
+
+
+def test_demo2_streams_thermostat_reasoning_and_action(client, monkeypatch):
+    class FakeOrchestrator:
+        async def submit(self, task):
+            assert task.payload["action"] == "set_temperature"
+            assert task.payload["domain"] == "climate"
+            assert task.payload["temperature"] == 78.0
+            assert task.metadata["source"] == "llm_climate_recommendation"
+            return "task-climate-1"
+
+        async def get_result(self, task_id):
+            assert task_id == "task-climate-1"
+            return Result(
+                success=True,
+                data={
+                    "action": "set_temperature",
+                    "verified": True,
+                    "execution_source": "home_assistant",
+                },
+                message="Device action completed",
+                agent="device",
+                task_id=task_id,
+                confidence=0.95,
+                metadata={
+                    "verified": True,
+                    "execution_source": "home_assistant",
+                },
+            )
+
+    class FakeLLMClient:
+        async def generate_structured(
+            self,
+            messages,
+            output_model,
+            system=None,
+            temperature=0.7,
+        ):
+            return output_model(
+                summary="The media room is warm, so use a moderate cooling target.",
+                recommended_temperature=78.0,
+                rationale="78 F improves comfort without aggressive cooling.",
+            )
+
+        async def close(self):
+            return None
+
+    async def fake_ha_state(input_data):
+        states = {
+            demo.DEMO_MEDIA_THERMOSTAT_ENTITY: ToolExecutionResult(
+                capability="ha_get_state",
+                result={
+                    "entity_id": demo.DEMO_MEDIA_THERMOSTAT_ENTITY,
+                    "state": "cool",
+                    "attributes": {
+                        "temperature": 78.0,
+                        "current_temperature": 82.0,
+                        "current_humidity": 59.0,
+                    },
+                },
+            ),
+            demo.DEMO_MEDIA_TEMPERATURE_SENSOR: ToolExecutionResult(
+                capability="ha_get_state",
+                result={
+                    "entity_id": demo.DEMO_MEDIA_TEMPERATURE_SENSOR,
+                    "state": "82.4",
+                    "attributes": {},
+                },
+            ),
+            demo.DEMO_MEDIA_HUMIDITY_SENSOR: ToolExecutionResult(
+                capability="ha_get_state",
+                result={
+                    "entity_id": demo.DEMO_MEDIA_HUMIDITY_SENSOR,
+                    "state": "59",
+                    "attributes": {},
+                },
+            ),
+        }
+        return states[input_data.entity_id]
+
+    monkeypatch.setattr(demo, "healthcheck_mysql", AsyncMock(return_value=True))
+    monkeypatch.setattr(demo, "healthcheck_arcadedb", AsyncMock(return_value=True))
+    monkeypatch.setattr(demo, "ha_get_state_handler", fake_ha_state)
+    monkeypatch.setattr(demo, "LLMClient", FakeLLMClient)
+    monkeypatch.setattr(demo, "_demo_orchestrator", FakeOrchestrator())
+
+    response = client.post("/demo/demo2", json={"code": "Demo2"})
+
+    assert response.status_code == 200
+    assert "Demo2 started" in response.text
+    assert "Media room climate snapshot" in response.text
+    assert "Thermostat LLM reasoning" in response.text
+    assert "Thermostat action result" in response.text
+    assert "Demo2 complete" in response.text
+    assert '"agent": "llm"' in response.text
+    assert '"agent": "device"' in response.text
+    assert '"bounded_temperature": 78.0' in response.text
+
+
+def test_periodic_feedback_returns_suggestions_only(client, monkeypatch):
+    class FakeLLMClient:
+        async def generate(
+            self,
+            prompt,
+            system=None,
+            temperature=0.7,
+            max_retries=3,
+            stream=False,
+        ):
+            return (
+                "Summary: House appears occupied with a few energy items to review.\n"
+                "- Review bedroom computer power because it is the highest current load.\n"
+                "- Garage looks secure because garage doors are closed in this snapshot."
+            )
+
+        async def close(self):
+            return None
+
+    states = [
+        {
+            "entity_id": "person.econest",
+            "state": "home",
+            "attributes": {"friendly_name": "econest"},
+        },
+        {
+            "entity_id": "light.bedroom_1_light_1",
+            "state": "on",
+            "attributes": {"friendly_name": "Bedroom 1 Light"},
+        },
+        {
+            "entity_id": "cover.garage12",
+            "state": "closed",
+            "attributes": {"friendly_name": "Garage Door"},
+        },
+        {
+            "entity_id": "sensor.sp7_power_minute_average",
+            "state": "63.1",
+            "attributes": {"friendly_name": "Bedroom 1 Computer Power Minute Average"},
+        },
+        {
+            "entity_id": "sensor.breaker_1_energy_today",
+            "state": "19.2",
+            "attributes": {"friendly_name": "Input Breaker Energy Today"},
+        },
+    ]
+
+    monkeypatch.setattr(demo, "_read_all_ha_states", AsyncMock(return_value=states))
+    monkeypatch.setattr(demo, "LLMClient", FakeLLMClient)
+
+    response = client.get("/demo/feedback")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "suggestions_only"
+    assert data["source"] == "ollama"
+    assert data["snapshot"]["occupancy_status"] == "home"
+    assert data["suggestions"][0]["category"] == "energy"
+    assert "action" not in data
+
+
+def test_light_policy_reasoning_guard_replaces_contradiction():
+    reasoning = demo._guard_light_policy_reasoning(
+        "The media room light should remain on even though no motion was detected.",
+        state="on",
+        recommended_action="turn_off",
+    )
+
+    assert "turn it off" in reasoning
+    assert "wasting energy" in reasoning

--- a/orchestrator/tests/test_mcp.py
+++ b/orchestrator/tests/test_mcp.py
@@ -4,9 +4,21 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from orchestrator.api import mcp
 from orchestrator.api.auth import get_current_user
 from orchestrator.core.database import get_mysql_session
 from orchestrator.main import app
+
+
+class _InstantClassifierLLM:
+    async def generate_structured(
+        self,
+        messages,
+        output_model,
+        system=None,
+        temperature=0.7,
+    ):
+        return output_model(category="energy", confidence=1.0)
 
 
 @pytest.fixture(autouse=True)
@@ -162,7 +174,8 @@ def test_mcp_stats_endpoint(client):
 
 
 @pytest.mark.anyio
-async def test_task_result_contains_agent_metadata(client):
+async def test_task_result_contains_agent_metadata(client, monkeypatch):
+    monkeypatch.setattr(mcp._orchestrator, "llm", _InstantClassifierLLM())
 
     response = client.post(
         "/mcp/task",


### PR DESCRIPTION
## Summary

- Switched intent classification to LLM-first routing with deterministic rule fallback for low-confidence, unknown, or failed model responses.
- Added confidence and reasoning fields to the intent classification model.
- Extended the device agent to support Home Assistant climate `set_temperature` actions and target-temperature verification.
- Added Demo2 for media-room thermostat reasoning with bounded climate recommendations.
- Added a passive Periodic Feedback panel to the demo frontend.
- Added `/demo/feedback` to read Home Assistant state, infer occupancy/energy/security context, and return suggestion-only feedback.
- Grounded feedback cards in observed Home Assistant facts before merging in Ollama wording, so suggestions remain concrete and do not take actions.
- Updated tests for LLM-first routing, Demo2, thermostat execution, feedback generation, and MCP task metadata isolation.

## Safety / Behavior

- Periodic feedback is suggestion-only and does not call Home Assistant action services.
- Thermostat Demo2 bounds any LLM recommendation to the configured demo range before passing it to the device agent.
- Device actions still route through the existing device agent and Home Assistant service layer.

## Validation

- `docker compose run --rm --no-deps orchestrator poetry run poe lint`
- `docker compose run --rm --no-deps orchestrator poetry run pytest orchestrator/tests/test_agents.py orchestrator/tests/test_demo.py orchestrator/tests/test_mcp.py -q`
- `docker compose run --rm --no-deps orchestrator poetry run poe test`

Full suite result on the clean PR branch: `195 passed`.
