### PR TITLE
Add autonomous audit logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ha_device_registry.json
 ha_entity_registry.json
 ha_states.json
 econest_exports/
+logs/

--- a/orchestrator/agents/base.py
+++ b/orchestrator/agents/base.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from orchestrator.core.audit import write_audit_event
 from orchestrator.core.permissions import AGENT_RUN
 from orchestrator.llm.client import LLMClient
 
@@ -150,3 +151,11 @@ class BaseAgent(ABC):
         }
         log_method = logger.info if result.success else logger.warning
         log_method(json.dumps(event, sort_keys=True))
+        write_audit_event(
+            "agent.run",
+            {
+                **event,
+                "confidence": result.confidence,
+                "metadata": result.metadata,
+            },
+        )

--- a/orchestrator/agents/orchestrator.py
+++ b/orchestrator/agents/orchestrator.py
@@ -13,6 +13,7 @@ from orchestrator.agents.device_agent import DeviceAgent
 from orchestrator.agents.energy_agent import EnergyAgent
 from orchestrator.agents.security_agent import SecurityAgent
 from orchestrator.agents.sensor_agent import SensorAgent
+from orchestrator.core.audit import write_audit_event
 from orchestrator.core.database import arcadedb_query
 from orchestrator.core.permissions import Role, normalize_role
 from orchestrator.llm.client import LLMClient
@@ -143,6 +144,16 @@ class AgentOrchestrator:
     async def submit(self, task: Task) -> str:
         """Submit a task and return a task ID."""
         task = task.model_copy(update={"id": task.id or str(uuid.uuid4())})
+        write_audit_event(
+            "task.submitted",
+            {
+                "task_id": task.id,
+                "intent": task.intent,
+                "user_id": task.user_id,
+                "metadata": task.metadata,
+                "payload": _audit_payload(task.payload),
+            },
+        )
         running_task = asyncio.create_task(self._run_with_lifecycle(task))
         self._tasks[task.id] = running_task
         self._stats["submitted"] += 1
@@ -154,19 +165,22 @@ class AgentOrchestrator:
         policy_result = await self._enforce_global_policy(task)
         if policy_result is not None:
             self._results[task.id] = policy_result
+            self._audit_task_result(task, policy_result, policy_blocked=True)
             if self._is_device_control_task(task):
                 await self._log_device_control_to_graph(task, policy_result)
             return
 
         agents = await self._select_agents(task)
         if not agents:
-            self._results[task.id] = Result(
+            result = Result(
                 success=False,
                 data={},
                 message="No agent could handle this task",
                 task_id=task.id,
                 error="no_agent",
             )
+            self._results[task.id] = result
+            self._audit_task_result(task, result)
             return
 
         results = await asyncio.gather(
@@ -181,6 +195,7 @@ class AgentOrchestrator:
 
         if self._is_device_control_task(task):
             await self._log_device_control_to_graph(task, result)
+        self._audit_task_result(task, result)
 
     async def _run_agent_with_retries(self, agent: BaseAgent, task: Task) -> Result:
         routed_task = task.model_copy(
@@ -364,6 +379,29 @@ class AgentOrchestrator:
             },
         )
 
+    def _audit_task_result(
+        self,
+        task: Task,
+        result: Result,
+        policy_blocked: bool = False,
+    ) -> None:
+        write_audit_event(
+            "task.completed",
+            {
+                "task_id": task.id,
+                "intent": task.intent,
+                "user_id": task.user_id,
+                "success": result.success,
+                "agent": result.agent,
+                "message": result.message,
+                "error": result.error,
+                "confidence": result.confidence,
+                "policy_blocked": policy_blocked,
+                "metadata": result.metadata,
+                "payload": _audit_payload(task.payload),
+            },
+        )
+
     async def _enforce_global_policy(self, task: Task) -> Result | None:
         role = self._task_role(task)
         if self._is_device_control_task(task) and self._is_restricted_control_hour():
@@ -443,3 +481,21 @@ class AgentOrchestrator:
 def _sql_string(value: Any) -> str:
     text = str(value).replace("\\", "\\\\").replace("'", "\\'")
     return f"'{text}'"
+
+
+def _audit_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Keep audit payloads useful without logging large or sensitive blobs."""
+    allowed_keys = {
+        "action",
+        "baseline_w",
+        "current_power_w",
+        "device_id",
+        "domain",
+        "entity_id",
+        "event_type",
+        "room",
+        "temperature",
+        "trigger",
+        "type",
+    }
+    return {key: payload[key] for key in allowed_keys if key in payload}

--- a/orchestrator/api/demo.py
+++ b/orchestrator/api/demo.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 from orchestrator.agents.base import Result, Task
 from orchestrator.agents.orchestrator import AgentOrchestrator
 from orchestrator.config import get_settings
+from orchestrator.core.audit import read_recent_audit_events, write_audit_event
 from orchestrator.core.database import healthcheck_arcadedb, healthcheck_mysql
 from orchestrator.core.permissions import Role
 from orchestrator.llm.client import LLMClient
@@ -111,6 +112,20 @@ async def periodic_feedback() -> dict[str, Any]:
     states = await _read_all_ha_states()
     snapshot = _build_household_feedback_snapshot(states)
     feedback = await _llm_periodic_feedback(snapshot)
+    write_audit_event(
+        "feedback.generated",
+        {
+            "mode": "suggestions_only",
+            "source": feedback["source"],
+            "suggestion_count": len(feedback["suggestions"]),
+            "occupancy_status": snapshot["occupancy_status"],
+            "lights_on_count": len(snapshot["lights_on"]),
+            "switches_on_count": len(snapshot["switches_on"]),
+            "active_motion_count": len(snapshot["active_motion"]),
+            "top_power_now_w": snapshot["top_power_now_w"][:3],
+            "warning": feedback["warning"],
+        },
+    )
     return {
         "mode": "suggestions_only",
         "source": feedback["source"],
@@ -118,6 +133,16 @@ async def periodic_feedback() -> dict[str, Any]:
         "summary": feedback["summary"],
         "suggestions": feedback["suggestions"],
         "snapshot": snapshot,
+    }
+
+
+@router.get("/audit")
+async def recent_audit(limit: int = 50) -> dict[str, Any]:
+    """Return recent autonomous runtime events from the durable audit log."""
+    bounded_limit = max(1, min(limit, 200))
+    return {
+        "events": read_recent_audit_events(bounded_limit),
+        "limit": bounded_limit,
     }
 
 

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -49,6 +49,8 @@ class Settings(BaseSettings):
 
     # Orchestrator
     ORCHESTRATOR_URL: str = ""
+    AUDIT_LOG_ENABLED: bool = True
+    AUDIT_LOG_PATH: str = "logs/audit.jsonl"
 
 
 @lru_cache

--- a/orchestrator/core/audit.py
+++ b/orchestrator/core/audit.py
@@ -1,0 +1,56 @@
+"""Durable JSONL audit logging for autonomous EcoNest behavior."""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from orchestrator.config import get_settings
+
+_LOCK = threading.Lock()
+
+
+def write_audit_event(event_type: str, payload: dict[str, Any]) -> None:
+    """Append a structured audit event to the local JSONL log."""
+    settings = get_settings()
+    if not settings.AUDIT_LOG_ENABLED:
+        return
+
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event_type": event_type,
+        **payload,
+    }
+    path = Path(settings.AUDIT_LOG_PATH)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with _LOCK, path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, default=str, sort_keys=True))
+            handle.write("\n")
+    except Exception:
+        return
+
+
+def read_recent_audit_events(limit: int = 50) -> list[dict[str, Any]]:
+    """Read the most recent audit events without failing the API."""
+    path = Path(get_settings().AUDIT_LOG_PATH)
+    if not path.exists():
+        return []
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return []
+
+    events: list[dict[str, Any]] = []
+    for line in lines[-limit:]:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            events.append(item)
+    return events

--- a/orchestrator/static/demo.html
+++ b/orchestrator/static/demo.html
@@ -153,7 +153,8 @@
 
       .summary,
       .timeline,
-      .feedback {
+      .feedback,
+      .audit {
         border: 1px solid var(--line);
         border-radius: 8px;
         background: var(--panel);
@@ -284,12 +285,14 @@
         text-align: center;
       }
 
-      .feedback {
+      .feedback,
+      .audit {
         margin-top: 18px;
         padding: 18px;
       }
 
-      .feedback-head {
+      .feedback-head,
+      .audit-head {
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -297,7 +300,8 @@
         margin-bottom: 14px;
       }
 
-      .feedback-head h2 {
+      .feedback-head h2,
+      .audit-head h2 {
         margin: 0;
         font-size: 17px;
       }
@@ -355,6 +359,30 @@
         font-size: 11px;
         font-weight: 700;
         text-transform: uppercase;
+      }
+
+      .audit-list {
+        display: grid;
+        gap: 10px;
+      }
+
+      .audit-event {
+        display: grid;
+        gap: 7px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 12px;
+        background: #fbfcfb;
+      }
+
+      .audit-event strong {
+        overflow-wrap: anywhere;
+      }
+
+      .audit-meta {
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.4;
       }
 
       @media (max-width: 820px) {
@@ -457,6 +485,16 @@
           <div class="empty">Waiting for feedback refresh.</div>
         </div>
       </section>
+
+      <section class="audit" aria-live="polite">
+        <div class="audit-head">
+          <h2>Recent Audit</h2>
+          <button id="auditButton" class="secondary" type="button">Refresh</button>
+        </div>
+        <div id="auditList" class="audit-list">
+          <div class="empty">Waiting for audit refresh.</div>
+        </div>
+      </section>
     </main>
 
     <script>
@@ -474,6 +512,8 @@
       const feedbackButton = document.getElementById("feedbackButton");
       const feedbackSummary = document.getElementById("feedbackSummary");
       const suggestions = document.getElementById("suggestions");
+      const auditButton = document.getElementById("auditButton");
+      const auditList = document.getElementById("auditList");
       const apiBase = resolveApiBase();
 
       if (shouldRedirectToBackend(apiBase)) {
@@ -482,8 +522,11 @@
 
       backend.textContent = apiBase;
       feedbackButton.addEventListener("click", refreshFeedback);
+      auditButton.addEventListener("click", refreshAudit);
       window.setTimeout(refreshFeedback, 800);
+      window.setTimeout(refreshAudit, 1100);
       window.setInterval(refreshFeedback, 120000);
+      window.setInterval(refreshAudit, 120000);
 
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
@@ -528,6 +571,7 @@
           setStatus("bad", "Failed");
         } finally {
           button.disabled = false;
+          refreshAudit();
         }
       });
 
@@ -625,6 +669,20 @@
         }
       }
 
+      async function refreshAudit() {
+        auditButton.disabled = true;
+        try {
+          const response = await fetch(`${apiBase}/demo/audit?limit=20`);
+          if (!response.ok) throw new Error(`Audit failed with ${response.status}`);
+          const data = await response.json();
+          renderAudit(data.events || []);
+        } catch (error) {
+          auditList.innerHTML = `<div class="empty">${error.message}</div>`;
+        } finally {
+          auditButton.disabled = false;
+        }
+      }
+
       function renderFeedback(data) {
         feedbackSummary.textContent = `${data.summary} Reasoning: ${data.source || "unknown"}.`;
         suggestions.innerHTML = "";
@@ -651,6 +709,39 @@
           card.querySelector("h3").textContent = item.title || "Suggestion";
           card.querySelector("p").textContent = item.detail || "";
           suggestions.appendChild(card);
+        });
+      }
+
+      function renderAudit(items) {
+        auditList.innerHTML = "";
+        if (!items.length) {
+          auditList.innerHTML = '<div class="empty">No audit events recorded yet.</div>';
+          return;
+        }
+
+        items.slice().reverse().forEach((item) => {
+          const card = document.createElement("article");
+          card.className = "audit-event";
+          card.innerHTML = `
+            <div class="tagline">
+              <span class="tag"></span>
+              <span class="tag"></span>
+            </div>
+            <strong></strong>
+            <div class="audit-meta"></div>
+          `;
+          const tags = card.querySelectorAll(".tag");
+          tags[0].textContent = item.event_type || "event";
+          tags[1].textContent = item.success === false ? "failed" : "recorded";
+          card.querySelector("strong").textContent = item.message || item.intent || item.summary || "Runtime event";
+          const meta = [
+            item.timestamp,
+            item.agent ? `agent: ${item.agent}` : null,
+            item.task_id ? `task: ${item.task_id}` : null,
+            item.confidence !== undefined ? `confidence: ${item.confidence}` : null,
+          ].filter(Boolean);
+          card.querySelector(".audit-meta").textContent = meta.join(" | ");
+          auditList.appendChild(card);
         });
       }
     </script>

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -15,6 +15,19 @@ from orchestrator.core.security import create_access_token
 from orchestrator.main import app
 
 
+@pytest.fixture(autouse=True)
+def disable_audit_log(monkeypatch):
+    """Keep routine tests from writing runtime audit logs into the repo."""
+
+    class AuditSettings:
+        AUDIT_LOG_ENABLED = False
+        AUDIT_LOG_PATH = "logs/test-audit.jsonl"
+
+    from orchestrator.core import audit
+
+    monkeypatch.setattr(audit, "get_settings", lambda: AuditSettings())
+
+
 @pytest.fixture
 def client():
     """Return a TestClient for the FastAPI app."""

--- a/orchestrator/tests/test_audit.py
+++ b/orchestrator/tests/test_audit.py
@@ -1,0 +1,38 @@
+"""Tests for durable autonomous audit logging."""
+
+from orchestrator.core import audit
+
+
+class _AuditSettings:
+    def __init__(self, path: str, enabled: bool = True) -> None:
+        self.AUDIT_LOG_ENABLED = enabled
+        self.AUDIT_LOG_PATH = path
+
+
+def test_audit_log_writes_and_reads_recent_events(tmp_path, monkeypatch):
+    path = tmp_path / "audit.jsonl"
+    monkeypatch.setattr(audit, "get_settings", lambda: _AuditSettings(str(path)))
+
+    audit.write_audit_event("task.submitted", {"task_id": "task-1"})
+    audit.write_audit_event("task.completed", {"task_id": "task-1", "success": True})
+
+    events = audit.read_recent_audit_events(limit=1)
+
+    assert len(events) == 1
+    assert events[0]["event_type"] == "task.completed"
+    assert events[0]["task_id"] == "task-1"
+    assert events[0]["success"] is True
+    assert "timestamp" in events[0]
+
+
+def test_audit_log_respects_disabled_setting(tmp_path, monkeypatch):
+    path = tmp_path / "audit.jsonl"
+    monkeypatch.setattr(
+        audit,
+        "get_settings",
+        lambda: _AuditSettings(str(path), enabled=False),
+    )
+
+    audit.write_audit_event("agent.run", {"task_id": "task-1"})
+
+    assert not path.exists()

--- a/orchestrator/tests/test_demo.py
+++ b/orchestrator/tests/test_demo.py
@@ -286,6 +286,30 @@ def test_periodic_feedback_returns_suggestions_only(client, monkeypatch):
     assert "action" not in data
 
 
+def test_demo_audit_returns_recent_events(client, monkeypatch):
+    monkeypatch.setattr(
+        demo,
+        "read_recent_audit_events",
+        lambda limit: [
+            {
+                "timestamp": "2026-06-14T00:00:00+00:00",
+                "event_type": "task.completed",
+                "task_id": "task-1",
+                "agent": "device",
+                "success": True,
+            }
+        ],
+    )
+
+    response = client.get("/demo/audit?limit=500")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["limit"] == 200
+    assert data["events"][0]["event_type"] == "task.completed"
+    assert data["events"][0]["agent"] == "device"
+
+
 def test_light_policy_reasoning_guard_replaces_contradiction():
     reasoning = demo._guard_light_policy_reasoning(
         "The media room light should remain on even though no motion was detected.",


### PR DESCRIPTION
## Summary
- Added durable JSONL audit logging for autonomous runtime events.
- Recorded task submissions, task completions, policy blocks, agent runs, and passive feedback generation.
- Added a `/demo/audit` endpoint and Recent Audit panel in the demo console.
- Ignored local runtime logs with `logs/` in `.gitignore`.
- Added tests for audit read/write behavior and the demo audit endpoint.

## Validation
- `docker compose run --rm --no-deps orchestrator poetry run poe lint`
- `docker compose run --rm --no-deps orchestrator poetry run poe test`