### PR TITLE
Harden autonomous monitoring architecture

### DIFF
--- a/database_schema.txt
+++ b/database_schema.txt
@@ -180,3 +180,19 @@ CREATE TABLE home_assistant_entities (
     INDEX idx_ha_entities_area_id (ha_area_id),
     FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
+CREATE TABLE audit_events (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    event_time TIMESTAMP(6) NOT NULL,
+    event_type VARCHAR(100) NOT NULL,
+    task_id VARCHAR(64),
+    agent VARCHAR(100),
+    success BOOLEAN,
+    source VARCHAR(100),
+    payload JSON NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_audit_event_time (event_time),
+    INDEX idx_audit_event_type (event_type),
+    INDEX idx_audit_task_id (task_id),
+    INDEX idx_audit_agent (agent)
+) ENGINE=InnoDB;

--- a/docker-compose.real.yml
+++ b/docker-compose.real.yml
@@ -91,6 +91,12 @@ services:
       HA_TOKEN: ${HA_TOKEN:?Set HA_TOKEN in your .env before starting econest-real}
       HA_REGISTRY_SOURCE: ${HA_REGISTRY_SOURCE:-live}
       SECRET_KEY: ${SECRET_KEY:-replace-this-for-local-demo-only}
+      AUDIT_LOG_MAX_BYTES: ${AUDIT_LOG_MAX_BYTES:-10485760}
+      AUDIT_LOG_BACKUP_COUNT: ${AUDIT_LOG_BACKUP_COUNT:-5}
+      AUTONOMY_MONITOR_ENABLED: ${AUTONOMY_MONITOR_ENABLED:-true}
+      AUTONOMY_MONITOR_INTERVAL_SECONDS: ${AUTONOMY_MONITOR_INTERVAL_SECONDS:-300}
+      AUTONOMY_MONITOR_RUN_ON_STARTUP: ${AUTONOMY_MONITOR_RUN_ON_STARTUP:-true}
+      AUTONOMY_ACTIONS_ENABLED: ${AUTONOMY_ACTIONS_ENABLED:-false}
     depends_on:
       arcadedb:
         condition: service_healthy

--- a/orchestrator/agents/device_agent.py
+++ b/orchestrator/agents/device_agent.py
@@ -182,6 +182,11 @@ class DeviceAgent(BaseAgent):
                 "agent_type": "device",
                 "verified": execution.verified,
                 "execution_source": execution.source,
+                "actual_outcome": {
+                    "device_id": request.entity_id or request.device_id,
+                    "state": execution.state,
+                    "verified": execution.verified,
+                },
             },
         )
 

--- a/orchestrator/agents/orchestrator.py
+++ b/orchestrator/agents/orchestrator.py
@@ -13,9 +13,10 @@ from orchestrator.agents.device_agent import DeviceAgent
 from orchestrator.agents.energy_agent import EnergyAgent
 from orchestrator.agents.security_agent import SecurityAgent
 from orchestrator.agents.sensor_agent import SensorAgent
-from orchestrator.core.audit import write_audit_event
+from orchestrator.core.audit import write_audit_event, write_audit_event_async
 from orchestrator.core.database import arcadedb_query
 from orchestrator.core.permissions import Role, normalize_role
+from orchestrator.core.policy import evaluate_autonomous_action_policy
 from orchestrator.llm.client import LLMClient
 from orchestrator.llm.models import LLMMessage
 
@@ -165,7 +166,7 @@ class AgentOrchestrator:
         policy_result = await self._enforce_global_policy(task)
         if policy_result is not None:
             self._results[task.id] = policy_result
-            self._audit_task_result(task, policy_result, policy_blocked=True)
+            await self._audit_task_result(task, policy_result, policy_blocked=True)
             if self._is_device_control_task(task):
                 await self._log_device_control_to_graph(task, policy_result)
             return
@@ -180,7 +181,7 @@ class AgentOrchestrator:
                 error="no_agent",
             )
             self._results[task.id] = result
-            self._audit_task_result(task, result)
+            await self._audit_task_result(task, result)
             return
 
         results = await asyncio.gather(
@@ -195,7 +196,7 @@ class AgentOrchestrator:
 
         if self._is_device_control_task(task):
             await self._log_device_control_to_graph(task, result)
-        self._audit_task_result(task, result)
+        await self._audit_task_result(task, result)
 
     async def _run_agent_with_retries(self, agent: BaseAgent, task: Task) -> Result:
         routed_task = task.model_copy(
@@ -379,13 +380,13 @@ class AgentOrchestrator:
             },
         )
 
-    def _audit_task_result(
+    async def _audit_task_result(
         self,
         task: Task,
         result: Result,
         policy_blocked: bool = False,
     ) -> None:
-        write_audit_event(
+        await write_audit_event_async(
             "task.completed",
             {
                 "task_id": task.id,
@@ -399,10 +400,32 @@ class AgentOrchestrator:
                 "policy_blocked": policy_blocked,
                 "metadata": result.metadata,
                 "payload": _audit_payload(task.payload),
+                "expected_outcome": task.payload.get("expected_outcome")
+                or task.metadata.get("expected_outcome"),
+                "actual_outcome": result.metadata.get("actual_outcome")
+                or result.metadata.get("verified"),
             },
         )
 
     async def _enforce_global_policy(self, task: Task) -> Result | None:
+        action_policy = evaluate_autonomous_action_policy(
+            task.payload,
+            task.metadata,
+            self._is_device_control_task(task),
+        )
+        if not action_policy.allowed:
+            return Result(
+                success=False,
+                data={},
+                message=action_policy.reason,
+                task_id=task.id,
+                error="policy_autonomous_action_restricted",
+                metadata={
+                    "source": task.metadata.get("source") or task.payload.get("source"),
+                    "expected_outcome": task.payload.get("expected_outcome"),
+                },
+            )
+
         role = self._task_role(task)
         if self._is_device_control_task(task) and self._is_restricted_control_hour():
             if role not in {Role.HOMEOWNER, Role.SUPERADMIN}:
@@ -497,5 +520,6 @@ def _audit_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "temperature",
         "trigger",
         "type",
+        "expected_outcome",
     }
     return {key: payload[key] for key in allowed_keys if key in payload}

--- a/orchestrator/api/demo.py
+++ b/orchestrator/api/demo.py
@@ -17,7 +17,11 @@ from pydantic import BaseModel, Field
 from orchestrator.agents.base import Result, Task
 from orchestrator.agents.orchestrator import AgentOrchestrator
 from orchestrator.config import get_settings
-from orchestrator.core.audit import read_recent_audit_events, write_audit_event
+from orchestrator.core.audit import (
+    read_recent_audit_events,
+    summarize_audit_events,
+    write_audit_event_async,
+)
 from orchestrator.core.database import healthcheck_arcadedb, healthcheck_mysql
 from orchestrator.core.permissions import Role
 from orchestrator.llm.client import LLMClient
@@ -109,14 +113,21 @@ async def run_demo2(req: DemoRequest) -> StreamingResponse:
 @router.get("/feedback")
 async def periodic_feedback() -> dict[str, Any]:
     """Return passive LLM-backed household feedback without taking actions."""
+    return await collect_periodic_feedback(trigger="api")
+
+
+async def collect_periodic_feedback(trigger: str = "manual") -> dict[str, Any]:
+    """Collect suggestion-only household feedback for UI or background monitoring."""
     states = await _read_all_ha_states()
     snapshot = _build_household_feedback_snapshot(states)
     feedback = await _llm_periodic_feedback(snapshot)
-    write_audit_event(
+    await write_audit_event_async(
         "feedback.generated",
         {
             "mode": "suggestions_only",
             "source": feedback["source"],
+            "summary": feedback["summary"],
+            "suggestions": feedback["suggestions"],
             "suggestion_count": len(feedback["suggestions"]),
             "occupancy_status": snapshot["occupancy_status"],
             "lights_on_count": len(snapshot["lights_on"]),
@@ -124,6 +135,7 @@ async def periodic_feedback() -> dict[str, Any]:
             "active_motion_count": len(snapshot["active_motion"]),
             "top_power_now_w": snapshot["top_power_now_w"][:3],
             "warning": feedback["warning"],
+            "trigger": trigger,
         },
     )
     return {
@@ -143,6 +155,17 @@ async def recent_audit(limit: int = 50) -> dict[str, Any]:
     return {
         "events": read_recent_audit_events(bounded_limit),
         "limit": bounded_limit,
+    }
+
+
+@router.get("/audit/summary")
+async def audit_summary(limit: int = 500) -> dict[str, Any]:
+    """Return aggregate health metrics from recent audit events."""
+    bounded_limit = max(1, min(limit, 5000))
+    events = read_recent_audit_events(bounded_limit)
+    return {
+        "limit": bounded_limit,
+        "summary": summarize_audit_events(events),
     }
 
 
@@ -228,6 +251,10 @@ async def _demo1_events() -> AsyncIterator[str]:
             "entity_id": DEMO_MEDIA_LIGHT_ENTITY,
             "domain": "light",
             "action": "turn_on",
+            "expected_outcome": {
+                "entity_id": DEMO_MEDIA_LIGHT_ENTITY,
+                "state": "on",
+            },
             "trigger": "Demo1",
             "user_role": Role.HOMEOWNER.value,
         },
@@ -307,6 +334,10 @@ async def _demo1_events() -> AsyncIterator[str]:
                 "entity_id": DEMO_MEDIA_LIGHT_ENTITY,
                 "domain": "light",
                 "action": "turn_off",
+                "expected_outcome": {
+                    "entity_id": DEMO_MEDIA_LIGHT_ENTITY,
+                    "state": "off",
+                },
                 "trigger": "Demo1",
                 "user_role": Role.HOMEOWNER.value,
             },
@@ -448,6 +479,11 @@ async def _demo2_events() -> AsyncIterator[str]:
             "domain": "climate",
             "action": "set_temperature",
             "temperature": setpoint,
+            "expected_outcome": {
+                "entity_id": DEMO_MEDIA_THERMOSTAT_ENTITY,
+                "attribute": "temperature",
+                "value": setpoint,
+            },
             "trigger": "Demo2",
             "user_role": Role.HOMEOWNER.value,
         },

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -51,6 +51,12 @@ class Settings(BaseSettings):
     ORCHESTRATOR_URL: str = ""
     AUDIT_LOG_ENABLED: bool = True
     AUDIT_LOG_PATH: str = "logs/audit.jsonl"
+    AUDIT_LOG_MAX_BYTES: int = 10_485_760
+    AUDIT_LOG_BACKUP_COUNT: int = 5
+    AUTONOMY_MONITOR_ENABLED: bool = False
+    AUTONOMY_MONITOR_INTERVAL_SECONDS: int = 300
+    AUTONOMY_MONITOR_RUN_ON_STARTUP: bool = True
+    AUTONOMY_ACTIONS_ENABLED: bool = False
 
 
 @lru_cache

--- a/orchestrator/core/audit.py
+++ b/orchestrator/core/audit.py
@@ -2,22 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import shutil
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from sqlalchemy import text
+
 from orchestrator.config import get_settings
+from orchestrator.core.database import mysql_session_context
 
 _LOCK = threading.Lock()
 
 
-def write_audit_event(event_type: str, payload: dict[str, Any]) -> None:
+def write_audit_event(event_type: str, payload: dict[str, Any]) -> dict[str, Any] | None:
     """Append a structured audit event to the local JSONL log."""
     settings = get_settings()
     if not settings.AUDIT_LOG_ENABLED:
-        return
+        return None
 
     event = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -30,8 +35,31 @@ def write_audit_event(event_type: str, payload: dict[str, Any]) -> None:
         with _LOCK, path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(event, default=str, sort_keys=True))
             handle.write("\n")
+        with _LOCK:
+            _rotate_if_needed(path)
     except Exception:
+        return None
+    _schedule_mysql_persist(event)
+    return event
+
+
+async def write_audit_event_async(
+    event_type: str,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Write an audit event to JSONL and persist it to MySQL when available."""
+    event = write_audit_event(event_type, payload)
+    if event is not None:
+        await persist_audit_event(event)
+    return event
+
+
+def _schedule_mysql_persist(event: dict[str, Any]) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
         return
+    loop.create_task(persist_audit_event(event))
 
 
 def read_recent_audit_events(limit: int = 50) -> list[dict[str, Any]]:
@@ -54,3 +82,154 @@ def read_recent_audit_events(limit: int = 50) -> list[dict[str, Any]]:
         if isinstance(item, dict):
             events.append(item)
     return events
+
+
+async def ensure_audit_table() -> None:
+    """Create the MySQL audit table used for long-term analysis."""
+    try:
+        async with mysql_session_context() as session:
+            await session.execute(
+                text(
+                    """
+                    CREATE TABLE IF NOT EXISTS audit_events (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        event_time TIMESTAMP(6) NOT NULL,
+                        event_type VARCHAR(100) NOT NULL,
+                        task_id VARCHAR(64),
+                        agent VARCHAR(100),
+                        success BOOLEAN,
+                        source VARCHAR(100),
+                        payload JSON NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        INDEX idx_audit_event_time (event_time),
+                        INDEX idx_audit_event_type (event_type),
+                        INDEX idx_audit_task_id (task_id),
+                        INDEX idx_audit_agent (agent)
+                    ) ENGINE=InnoDB
+                    """
+                )
+            )
+            await session.commit()
+    except Exception:
+        return
+
+
+async def persist_audit_event(event: dict[str, Any]) -> None:
+    """Persist one audit event to MySQL without breaking runtime behavior."""
+    try:
+        async with mysql_session_context() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO audit_events
+                        (event_time, event_type, task_id, agent, success, source, payload)
+                    VALUES
+                        (:event_time, :event_type, :task_id, :agent, :success, :source, :payload)
+                    """
+                ),
+                {
+                    "event_time": _mysql_timestamp(event.get("timestamp")),
+                    "event_type": str(event.get("event_type", ""))[:100],
+                    "task_id": _optional_text(event.get("task_id"), 64),
+                    "agent": _optional_text(event.get("agent"), 100),
+                    "success": event.get("success")
+                    if isinstance(event.get("success"), bool)
+                    else None,
+                    "source": _optional_text(event.get("source"), 100),
+                    "payload": json.dumps(event, default=str, sort_keys=True),
+                },
+            )
+            await session.commit()
+    except Exception:
+        return
+
+
+def summarize_audit_events(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build simple long-term health metrics from recent audit events."""
+    task_results = [
+        event for event in events if event.get("event_type") == "task.completed"
+    ]
+    failed = [event for event in task_results if event.get("success") is False]
+    routed_agents: dict[str, int] = {}
+    suggestion_titles: dict[str, int] = {}
+    feedback_count = 0
+
+    for event in events:
+        agent = event.get("agent")
+        if isinstance(agent, str) and agent:
+            routed_agents[agent] = routed_agents.get(agent, 0) + 1
+        if event.get("event_type") == "feedback.generated":
+            feedback_count += 1
+            for title in _suggestion_titles(event):
+                suggestion_titles[title] = suggestion_titles.get(title, 0) + 1
+
+    completed_count = len(task_results)
+    success_count = completed_count - len(failed)
+    return {
+        "event_count": len(events),
+        "task_completed_count": completed_count,
+        "task_success_count": success_count,
+        "task_failed_count": len(failed),
+        "task_success_rate": (
+            round(success_count / completed_count, 3) if completed_count else None
+        ),
+        "feedback_count": feedback_count,
+        "failed_actions": failed[-10:],
+        "agent_routing": _top_counts(routed_agents),
+        "common_suggestions": _top_counts(suggestion_titles),
+        "latest_event": events[-1] if events else None,
+    }
+
+
+def _rotate_if_needed(path: Path) -> None:
+    settings = get_settings()
+    max_bytes = settings.AUDIT_LOG_MAX_BYTES
+    if max_bytes <= 0 or not path.exists() or path.stat().st_size <= max_bytes:
+        return
+
+    backups = max(1, settings.AUDIT_LOG_BACKUP_COUNT)
+    for index in range(backups - 1, 0, -1):
+        source = path.with_name(f"{path.name}.{index}")
+        target = path.with_name(f"{path.name}.{index + 1}")
+        if source.exists():
+            if target.exists():
+                target.unlink()
+            source.rename(target)
+    first_backup = path.with_name(f"{path.name}.1")
+    if first_backup.exists():
+        first_backup.unlink()
+    shutil.move(str(path), str(first_backup))
+    path.touch()
+
+
+def _mysql_timestamp(value: Any) -> str:
+    if isinstance(value, str):
+        return value.replace("T", " ").replace("+00:00", "")[:26]
+    return datetime.now(timezone.utc).isoformat().replace("T", " ")[:26]
+
+
+def _optional_text(value: Any, limit: int) -> str | None:
+    if value is None:
+        return None
+    return str(value)[:limit]
+
+
+def _suggestion_titles(event: dict[str, Any]) -> list[str]:
+    suggestions = event.get("suggestions")
+    if not isinstance(suggestions, list):
+        return []
+    titles = []
+    for item in suggestions:
+        if isinstance(item, dict) and isinstance(item.get("title"), str):
+            titles.append(item["title"])
+    return titles
+
+
+def _top_counts(counts: dict[str, int], limit: int = 10) -> list[dict[str, Any]]:
+    return [
+        {"name": name, "count": count}
+        for name, count in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )[:limit]
+    ]

--- a/orchestrator/core/autonomy.py
+++ b/orchestrator/core/autonomy.py
@@ -1,0 +1,131 @@
+"""Background autonomous monitoring loop for long-term test data."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from orchestrator.core.audit import write_audit_event, write_audit_event_async
+
+FeedbackCollector = Callable[[], Awaitable[dict[str, Any]]]
+
+
+class AutonomousMonitor:
+    """Periodically collect passive household feedback without a browser."""
+
+    def __init__(
+        self,
+        collect_feedback: FeedbackCollector,
+        interval_seconds: int,
+        run_on_startup: bool = True,
+    ) -> None:
+        self.collect_feedback = collect_feedback
+        self.interval_seconds = max(15, interval_seconds)
+        self.run_on_startup = run_on_startup
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+        self.started_at: str | None = None
+        self.last_run_at: str | None = None
+        self.last_success_at: str | None = None
+        self.last_failure_at: str | None = None
+        self.last_error: str | None = None
+        self.run_count = 0
+        self.success_count = 0
+        self.failure_count = 0
+
+    def start(self) -> None:
+        """Start the monitor loop if it is not already running."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stop_event.clear()
+        self.started_at = _utc_now()
+        self._task = asyncio.create_task(self._run(), name="econest-autonomous-monitor")
+        write_audit_event(
+            "autonomy.monitor.started",
+            {
+                "interval_seconds": self.interval_seconds,
+                "run_on_startup": self.run_on_startup,
+            },
+        )
+
+    async def stop(self) -> None:
+        """Stop the monitor loop and wait for shutdown."""
+        self._stop_event.set()
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        write_audit_event("autonomy.monitor.stopped", {})
+
+    def status(self) -> dict[str, Any]:
+        """Return read-only monitor runtime status."""
+        return {
+            "enabled": True,
+            "running": self._task is not None and not self._task.done(),
+            "interval_seconds": self.interval_seconds,
+            "run_on_startup": self.run_on_startup,
+            "started_at": self.started_at,
+            "last_run_at": self.last_run_at,
+            "last_success_at": self.last_success_at,
+            "last_failure_at": self.last_failure_at,
+            "last_error": self.last_error,
+            "run_count": self.run_count,
+            "success_count": self.success_count,
+            "failure_count": self.failure_count,
+        }
+
+    async def _run(self) -> None:
+        if self.run_on_startup:
+            await self.run_once()
+
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=self.interval_seconds,
+                )
+            except TimeoutError:
+                await self.run_once()
+
+    async def run_once(self) -> dict[str, Any] | None:
+        """Collect one feedback sample and record success or failure."""
+        self.run_count += 1
+        self.last_run_at = _utc_now()
+        try:
+            result = await self.collect_feedback()
+        except Exception as exc:
+            self.failure_count += 1
+            self.last_failure_at = _utc_now()
+            self.last_error = str(exc)
+            await write_audit_event_async(
+                "autonomy.monitor.failed",
+                {
+                    "success": False,
+                    "error": exc.__class__.__name__,
+                    "message": str(exc),
+                },
+            )
+            return None
+
+        self.success_count += 1
+        self.last_success_at = _utc_now()
+        self.last_error = None
+        await write_audit_event_async(
+            "autonomy.monitor.completed",
+            {
+                "success": True,
+                "source": result.get("source"),
+                "suggestion_count": len(result.get("suggestions", [])),
+                "occupancy_status": result.get("snapshot", {}).get("occupancy_status"),
+            },
+        )
+        return result
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/orchestrator/core/database.py
+++ b/orchestrator/core/database.py
@@ -47,6 +47,9 @@ async def init_databases() -> None:
         timeout=httpx.Timeout(30.0),
         headers={"Content-Type": "application/json"},
     )
+    from orchestrator.core.audit import ensure_audit_table
+
+    await ensure_audit_table()
 
 
 async def close_databases() -> None:

--- a/orchestrator/core/policy.py
+++ b/orchestrator/core/policy.py
@@ -1,0 +1,47 @@
+"""Policy gates for autonomous EcoNest behavior."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from orchestrator.config import get_settings
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Result of evaluating whether a task is allowed."""
+
+    allowed: bool
+    reason: str = ""
+
+
+AUTONOMOUS_SOURCES = {
+    "autonomous_monitor",
+    "background_monitor",
+    "scheduled_autonomy",
+}
+
+
+def evaluate_autonomous_action_policy(
+    payload: dict[str, Any],
+    metadata: dict[str, Any],
+    is_device_control: bool,
+) -> PolicyDecision:
+    """Block autonomous device actions unless explicitly enabled."""
+    if not is_device_control:
+        return PolicyDecision(allowed=True)
+
+    source = str(metadata.get("source") or payload.get("source") or "")
+    trigger = str(metadata.get("trigger") or payload.get("trigger") or "")
+    is_autonomous = source in AUTONOMOUS_SOURCES or trigger in AUTONOMOUS_SOURCES
+    if not is_autonomous:
+        return PolicyDecision(allowed=True)
+
+    if get_settings().AUTONOMY_ACTIONS_ENABLED:
+        return PolicyDecision(allowed=True)
+
+    return PolicyDecision(
+        allowed=False,
+        reason="Autonomous device actions require AUTONOMY_ACTIONS_ENABLED=true",
+    )

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 from orchestrator.api import auth, demo, devices, graph, mcp, ontology, readings, users
 from orchestrator.config import get_settings
+from orchestrator.core.autonomy import AutonomousMonitor
 from orchestrator.core.database import (
     close_databases,
     healthcheck_arcadedb,
@@ -17,14 +18,28 @@ from orchestrator.core.database import (
 from orchestrator.mcp import server as mcp_server
 
 settings = get_settings()
+autonomous_monitor: AutonomousMonitor | None = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Manage database connections across the application lifespan."""
+    global autonomous_monitor
     await init_databases()
-    yield
-    await close_databases()
+    if settings.AUTONOMY_MONITOR_ENABLED:
+        autonomous_monitor = AutonomousMonitor(
+            lambda: demo.collect_periodic_feedback(trigger="background_monitor"),
+            interval_seconds=settings.AUTONOMY_MONITOR_INTERVAL_SECONDS,
+            run_on_startup=settings.AUTONOMY_MONITOR_RUN_ON_STARTUP,
+        )
+        autonomous_monitor.start()
+    try:
+        yield
+    finally:
+        if autonomous_monitor is not None:
+            await autonomous_monitor.stop()
+            autonomous_monitor = None
+        await close_databases()
 
 
 app = FastAPI(
@@ -62,3 +77,19 @@ async def health_check() -> dict[str, Any]:
             "arcadedb": arcadedb_ok,
         },
     }
+
+
+@app.get("/autonomy/status")
+async def autonomy_status() -> dict[str, Any]:
+    """Read-only status for the background autonomous monitor."""
+    if autonomous_monitor is None:
+        return {
+            "enabled": settings.AUTONOMY_MONITOR_ENABLED,
+            "running": False,
+            "interval_seconds": settings.AUTONOMY_MONITOR_INTERVAL_SECONDS,
+            "run_on_startup": settings.AUTONOMY_MONITOR_RUN_ON_STARTUP,
+            "actions_enabled": settings.AUTONOMY_ACTIONS_ENABLED,
+        }
+    status = autonomous_monitor.status()
+    status["actions_enabled"] = settings.AUTONOMY_ACTIONS_ENABLED
+    return status

--- a/orchestrator/replay/__init__.py
+++ b/orchestrator/replay/__init__.py
@@ -1,0 +1,1 @@
+"""Replay utilities for evaluating EcoNest behavior against stored snapshots."""

--- a/orchestrator/replay/harness.py
+++ b/orchestrator/replay/harness.py
@@ -1,0 +1,57 @@
+"""Replay stored Home Assistant snapshots through deterministic EcoNest checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from orchestrator.api.demo import (
+    FeedbackSuggestion,
+    _build_household_feedback_snapshot,
+    _fallback_periodic_feedback,
+)
+
+
+@dataclass(frozen=True)
+class ReplayScenario:
+    """A stored snapshot and the outcomes expected from EcoNest analysis."""
+
+    name: str
+    states: list[dict[str, Any]]
+    expected_categories: set[str] = field(default_factory=set)
+    expected_titles: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Result of replaying one scenario."""
+
+    name: str
+    passed: bool
+    missing_categories: set[str]
+    missing_titles: set[str]
+    suggestions: list[FeedbackSuggestion]
+    snapshot: dict[str, Any]
+
+
+def replay_feedback_scenarios(scenarios: list[ReplayScenario]) -> list[ReplayResult]:
+    """Run stored snapshots through deterministic feedback expectations."""
+    return [replay_feedback_scenario(scenario) for scenario in scenarios]
+
+
+def replay_feedback_scenario(scenario: ReplayScenario) -> ReplayResult:
+    """Replay one snapshot and compare suggestions to expected outcomes."""
+    snapshot = _build_household_feedback_snapshot(scenario.states)
+    feedback = _fallback_periodic_feedback(snapshot)
+    categories = {suggestion.category for suggestion in feedback.suggestions}
+    titles = {suggestion.title for suggestion in feedback.suggestions}
+    missing_categories = scenario.expected_categories - categories
+    missing_titles = scenario.expected_titles - titles
+    return ReplayResult(
+        name=scenario.name,
+        passed=not missing_categories and not missing_titles,
+        missing_categories=missing_categories,
+        missing_titles=missing_titles,
+        suggestions=feedback.suggestions,
+        snapshot=snapshot,
+    )

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -22,6 +22,8 @@ def disable_audit_log(monkeypatch):
     class AuditSettings:
         AUDIT_LOG_ENABLED = False
         AUDIT_LOG_PATH = "logs/test-audit.jsonl"
+        AUDIT_LOG_MAX_BYTES = 10_485_760
+        AUDIT_LOG_BACKUP_COUNT = 5
 
     from orchestrator.core import audit
 

--- a/orchestrator/tests/test_agents.py
+++ b/orchestrator/tests/test_agents.py
@@ -578,6 +578,36 @@ async def test_orchestrator_blocks_guest_device_control_at_night():
 
 
 @pytest.mark.anyio
+async def test_orchestrator_blocks_autonomous_device_actions_by_default():
+    orch = AgentOrchestrator(
+        agents=[_StaticAgent("device")],
+        current_hour_provider=lambda: 12,
+    )
+    task = Task(
+        id="policy-auto-1",
+        intent="autonomous turn off light",
+        payload={
+            "action": "turn_off",
+            "domain": "light",
+            "expected_outcome": {"state": "off"},
+        },
+        metadata={"source": "background_monitor", "user_role": "homeowner"},
+    )
+
+    with patch(
+        "orchestrator.agents.orchestrator.arcadedb_query",
+        new=AsyncMock(return_value={"result": []}),
+    ):
+        await orch._run_with_lifecycle(task)
+
+    result = await orch.get_result("policy-auto-1")
+    assert result is not None
+    assert not result.success
+    assert result.error == "policy_autonomous_action_restricted"
+    assert result.metadata["expected_outcome"] == {"state": "off"}
+
+
+@pytest.mark.anyio
 async def test_orchestrator_allows_homeowner_device_control_at_night():
     orch = AgentOrchestrator(
         agents=[_StaticAgent("device")],

--- a/orchestrator/tests/test_audit.py
+++ b/orchestrator/tests/test_audit.py
@@ -4,9 +4,17 @@ from orchestrator.core import audit
 
 
 class _AuditSettings:
-    def __init__(self, path: str, enabled: bool = True) -> None:
+    def __init__(
+        self,
+        path: str,
+        enabled: bool = True,
+        max_bytes: int = 10_485_760,
+        backup_count: int = 5,
+    ) -> None:
         self.AUDIT_LOG_ENABLED = enabled
         self.AUDIT_LOG_PATH = path
+        self.AUDIT_LOG_MAX_BYTES = max_bytes
+        self.AUDIT_LOG_BACKUP_COUNT = backup_count
 
 
 def test_audit_log_writes_and_reads_recent_events(tmp_path, monkeypatch):
@@ -36,3 +44,48 @@ def test_audit_log_respects_disabled_setting(tmp_path, monkeypatch):
     audit.write_audit_event("agent.run", {"task_id": "task-1"})
 
     assert not path.exists()
+
+
+def test_audit_log_rotates_when_size_limit_is_reached(tmp_path, monkeypatch):
+    path = tmp_path / "audit.jsonl"
+    monkeypatch.setattr(
+        audit,
+        "get_settings",
+        lambda: _AuditSettings(str(path), max_bytes=80, backup_count=2),
+    )
+
+    audit.write_audit_event("task.submitted", {"task_id": "task-1", "data": "x" * 80})
+
+    assert path.exists()
+    assert path.with_name("audit.jsonl.1").exists()
+
+
+def test_audit_summary_calculates_operational_metrics():
+    summary = audit.summarize_audit_events(
+        [
+            {
+                "event_type": "task.completed",
+                "task_id": "task-1",
+                "agent": "device",
+                "success": True,
+            },
+            {
+                "event_type": "task.completed",
+                "task_id": "task-2",
+                "agent": "energy",
+                "success": False,
+            },
+            {
+                "event_type": "feedback.generated",
+                "suggestions": [{"title": "Review current load"}],
+            },
+        ]
+    )
+
+    assert summary["task_completed_count"] == 2
+    assert summary["task_success_rate"] == 0.5
+    assert summary["task_failed_count"] == 1
+    assert summary["agent_routing"][0] == {"name": "device", "count": 1}
+    assert summary["common_suggestions"] == [
+        {"name": "Review current load", "count": 1}
+    ]

--- a/orchestrator/tests/test_autonomy.py
+++ b/orchestrator/tests/test_autonomy.py
@@ -1,0 +1,65 @@
+"""Tests for background autonomous monitoring."""
+
+from orchestrator.core import autonomy
+from orchestrator.core.autonomy import AutonomousMonitor
+
+
+async def test_autonomous_monitor_run_once_records_success(monkeypatch):
+    events = []
+
+    async def collect_feedback():
+        return {
+            "source": "ollama",
+            "suggestions": [{"title": "Review load"}],
+            "snapshot": {"occupancy_status": "home"},
+        }
+
+    async def fake_write(event_type, payload):
+        events.append((event_type, payload))
+
+    monkeypatch.setattr(autonomy, "write_audit_event_async", fake_write)
+
+    monitor = AutonomousMonitor(
+        collect_feedback,
+        interval_seconds=1,
+    )
+    result = await monitor.run_once()
+
+    assert result is not None
+    assert monitor.status()["success_count"] == 1
+    assert events == [
+        (
+            "autonomy.monitor.completed",
+            {
+                "success": True,
+                "source": "ollama",
+                "suggestion_count": 1,
+                "occupancy_status": "home",
+            },
+        )
+    ]
+
+
+async def test_autonomous_monitor_run_once_records_failure(monkeypatch):
+    events = []
+
+    async def collect_feedback():
+        raise RuntimeError("Home Assistant unavailable")
+
+    async def fake_write(event_type, payload):
+        events.append((event_type, payload))
+
+    monkeypatch.setattr(autonomy, "write_audit_event_async", fake_write)
+
+    monitor = AutonomousMonitor(
+        collect_feedback,
+        interval_seconds=1,
+    )
+    result = await monitor.run_once()
+
+    assert result is None
+    assert monitor.status()["failure_count"] == 1
+    assert monitor.status()["last_error"] == "Home Assistant unavailable"
+    assert events[0][0] == "autonomy.monitor.failed"
+    assert events[0][1]["success"] is False
+    assert events[0][1]["error"] == "RuntimeError"

--- a/orchestrator/tests/test_demo.py
+++ b/orchestrator/tests/test_demo.py
@@ -310,6 +310,35 @@ def test_demo_audit_returns_recent_events(client, monkeypatch):
     assert data["events"][0]["agent"] == "device"
 
 
+def test_demo_audit_summary_returns_metrics(client, monkeypatch):
+    monkeypatch.setattr(
+        demo,
+        "read_recent_audit_events",
+        lambda limit: [
+            {
+                "event_type": "task.completed",
+                "task_id": "task-1",
+                "agent": "device",
+                "success": True,
+            },
+            {
+                "event_type": "task.completed",
+                "task_id": "task-2",
+                "agent": "device",
+                "success": False,
+            },
+        ],
+    )
+
+    response = client.get("/demo/audit/summary?limit=9999")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["limit"] == 5000
+    assert data["summary"]["task_completed_count"] == 2
+    assert data["summary"]["task_success_rate"] == 0.5
+
+
 def test_light_policy_reasoning_guard_replaces_contradiction():
     reasoning = demo._guard_light_policy_reasoning(
         "The media room light should remain on even though no motion was detected.",

--- a/orchestrator/tests/test_main.py
+++ b/orchestrator/tests/test_main.py
@@ -1,0 +1,19 @@
+"""Tests for application-level status endpoints."""
+
+from orchestrator import main
+
+
+def test_autonomy_status_reports_disabled_monitor(client, monkeypatch):
+    monkeypatch.setattr(main, "autonomous_monitor", None)
+    monkeypatch.setattr(main.settings, "AUTONOMY_MONITOR_ENABLED", False)
+    monkeypatch.setattr(main.settings, "AUTONOMY_MONITOR_INTERVAL_SECONDS", 300)
+    monkeypatch.setattr(main.settings, "AUTONOMY_MONITOR_RUN_ON_STARTUP", True)
+    monkeypatch.setattr(main.settings, "AUTONOMY_ACTIONS_ENABLED", False)
+
+    response = client.get("/autonomy/status")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["enabled"] is False
+    assert data["running"] is False
+    assert data["actions_enabled"] is False

--- a/orchestrator/tests/test_replay.py
+++ b/orchestrator/tests/test_replay.py
@@ -1,0 +1,34 @@
+"""Tests for replaying stored Home Assistant snapshots."""
+
+from orchestrator.replay.harness import ReplayScenario, replay_feedback_scenarios
+
+
+def test_replay_feedback_scenario_matches_expected_category():
+    scenario = ReplayScenario(
+        name="away-house-light-on",
+        states=[
+            {
+                "entity_id": "person.econest",
+                "state": "not_home",
+                "attributes": {"friendly_name": "econest"},
+            },
+            {
+                "entity_id": "light.media_room",
+                "state": "on",
+                "attributes": {"friendly_name": "Media Room Light"},
+            },
+            {
+                "entity_id": "sensor.breaker_1_power_minute_average",
+                "state": "1200",
+                "attributes": {"friendly_name": "Input Breaker Power Minute Average"},
+            },
+        ],
+        expected_categories={"energy"},
+        expected_titles={"Lights are on while the house appears away"},
+    )
+
+    results = replay_feedback_scenarios([scenario])
+
+    assert len(results) == 1
+    assert results[0].passed
+    assert results[0].snapshot["occupancy_status"] == "away"


### PR DESCRIPTION
## Summary
- Added a browser-independent autonomous monitor for periodic passive feedback collection.
- Added audit log rotation so `logs/audit.jsonl` has bounded growth with backups.
- Persisted audit events to MySQL through an automatically created `audit_events` table.
- Added `/demo/audit/summary` for success rates, failed actions, common suggestions, and agent routing.
- Added `/autonomy/status` for monitor state, last run time, failures, and action-policy state.
- Added expected outcome and actual outcome audit fields for device actions.
- Added an autonomous action policy gate so passive monitoring cannot execute device actions unless explicitly enabled.
- Added a replay harness for stored Home Assistant snapshots and deterministic expected-outcome checks.
- Added tests for audit rotation/summary, autonomy status, action policy, and replay behavior.

## Validation
- `docker compose run --rm --no-deps orchestrator poetry run poe lint`
- `docker compose run --rm --no-deps orchestrator poetry run poe test`
- Rebuilt `docker-compose.real.yml` orchestrator successfully.
- Verified `/health`, `/autonomy/status`, `/demo/audit/summary`, and MySQL `audit_events` on the real stack.